### PR TITLE
support for ROS2 galactic

### DIFF
--- a/extra/src/vtr_testing_lidar/src/localization.cpp
+++ b/extra/src/vtr_testing_lidar/src/localization.cpp
@@ -2,6 +2,7 @@
 
 #include "rosbag2_cpp/reader.hpp"
 #include "rosbag2_cpp/readers/sequential_reader.hpp"
+#include "rosbag2_cpp/storage_options.hpp"
 
 #include "rclcpp/serialization.hpp"
 #include "rclcpp/serialized_message.hpp"

--- a/extra/src/vtr_testing_lidar/src/odometry.cpp
+++ b/extra/src/vtr_testing_lidar/src/odometry.cpp
@@ -5,6 +5,7 @@
 
 #include "rclcpp/serialization.hpp"
 #include "rclcpp/serialized_message.hpp"
+#include "rosbag2_cpp/storage_options.hpp"
 
 #include <vtr_common/timing/time_utils.hpp>
 #include <vtr_common/utils/filesystem.hpp>

--- a/main/src/vtr_common/vtr_include.cmake
+++ b/main/src/vtr_common/vtr_include.cmake
@@ -27,6 +27,13 @@ if (OpenMP_FOUND)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 endif()
 
+## Compile for different ROS versions
+if(DEFINED ENV{ROS_DISTRO})
+  if("$ENV{ROS_DISTRO}" STREQUAL "foxy")
+    add_definitions(-DVTR_ROS_FOXY)
+  endif()
+endif()
+
 ## Make VT&R run deterministically
 # Note: these flags disable multi-threading in VTR tactic and pipelines, use
 # with care and for debugging only.

--- a/main/src/vtr_storage/src/accessor/sequential_append_writer.cpp
+++ b/main/src/vtr_storage/src/accessor/sequential_append_writer.cpp
@@ -26,6 +26,7 @@
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include <sstream>
 
 #include "rcpputils/filesystem_helper.hpp"
 

--- a/main/src/vtr_storage/src/accessor/sequential_writer.cpp
+++ b/main/src/vtr_storage/src/accessor/sequential_writer.cpp
@@ -26,6 +26,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <sstream>
 #include <utility>
 
 #include "rcpputils/filesystem_helper.hpp"

--- a/main/src/vtr_storage/src/metadata_io.cpp
+++ b/main/src/vtr_storage/src/metadata_io.cpp
@@ -278,7 +278,13 @@ BagMetadata MetadataIo::read_metadata(const std::string & uri)
     YAML::Node yaml_file = YAML::LoadFile(get_metadata_file_name(uri));
     auto metadata = yaml_file["rosbag2_bagfile_information"].as<BagMetadata>();
     rcutils_allocator_t allocator = rcutils_get_default_allocator();
-    metadata.bag_size = rcutils_calculate_directory_size(uri.c_str(), allocator);
+    // metadata.bag_size = rcutils_calculate_directory_size(uri.c_str(), allocator);
+    if (RCUTILS_RET_OK !=
+      rcutils_calculate_directory_size(uri.c_str(), &metadata.bag_size, allocator))
+    {
+      throw std::runtime_error(
+        std::string("Exception on calculating the size of directory :") + uri);
+    }
     return metadata;
   } catch (const YAML::Exception & ex) {
     throw std::runtime_error(std::string("Exception on parsing info file: ") + ex.what());

--- a/main/src/vtr_storage/src/metadata_io.cpp
+++ b/main/src/vtr_storage/src/metadata_io.cpp
@@ -278,13 +278,18 @@ BagMetadata MetadataIo::read_metadata(const std::string & uri)
     YAML::Node yaml_file = YAML::LoadFile(get_metadata_file_name(uri));
     auto metadata = yaml_file["rosbag2_bagfile_information"].as<BagMetadata>();
     rcutils_allocator_t allocator = rcutils_get_default_allocator();
-    // metadata.bag_size = rcutils_calculate_directory_size(uri.c_str(), allocator);
+#ifdef VTR_ROS_FOXY
+    // ROS2 foxy api
+    metadata.bag_size = rcutils_calculate_directory_size(uri.c_str(), allocator);
+#else
+    // ROS2 >=galactic api
     if (RCUTILS_RET_OK !=
       rcutils_calculate_directory_size(uri.c_str(), &metadata.bag_size, allocator))
     {
       throw std::runtime_error(
         std::string("Exception on calculating the size of directory :") + uri);
     }
+#endif
     return metadata;
   } catch (const YAML::Exception & ex) {
     throw std::runtime_error(std::string("Exception on parsing info file: ") + ex.what());


### PR DESCRIPTION
## Changes
- ROS2 Galactic support
  - now supporting both Foxy and Galactic
  - note that Galactic changes default RMW to Eclipse Cyclone DDS - for reasons this makes it hard to communicate with Grizzly which uses ROS2 C-- and ROS1 J--, so do not use Galactic if you want to run VTR online with Grizzly. This won't be a problem with other more recent robots.