### PR TITLE
Partial warnings fix

### DIFF
--- a/main/src/vtr_gui/setup.cfg
+++ b/main/src/vtr_gui/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/vtr_gui
+script_dir=$base/lib/vtr_gui
 [install]
-install-scripts=$base/lib/vtr_gui
+install_scripts=$base/lib/vtr_gui


### PR DESCRIPTION
Only 1 of the warnings can be removed. 

The setup.py deprecation is an issue with colcon build itself.

See 
https://github.com/colcon/colcon-core/issues/454
for details.