### PR TITLE
Fixed small bug, stamp still needs to be loaded into function

### DIFF
--- a/main/src/vtr_lidar/src/modules/preprocessing/conversions/velodyne_conversion_module.cpp
+++ b/main/src/vtr_lidar/src/modules/preprocessing/conversions/velodyne_conversion_module.cpp
@@ -73,7 +73,7 @@ void VelodyneConversionModule::run_(QueryCache &qdata0, OutputCache &,
   // Stamp loading was added for unknown reason. Current velodyne data (e.g. from Boreas)
   // has timestamps loaded in absolute time, starting from stamp time. Thus, adding stamp
   // to the timestamp in line 89/90 is incorrect. Perhaps there is data where this is not true...
-  //const auto &stamp = *qdata.stamp; 
+  const auto &stamp = *qdata.stamp; 
   const auto &points = *qdata.points;
 
   auto point_cloud =


### PR DESCRIPTION
Found a small bug that prevent package from building. The stamp is used in the visualization part of the function, even if it is not needed for correcting timestamps (this was the previous bug that was fixed).