### PR TITLE
Add Stationary Planner

### DIFF
--- a/launch/offline_honeycomb_grizzly.launch.yaml
+++ b/launch/offline_honeycomb_grizzly.launch.yaml
@@ -21,6 +21,7 @@ windows:
         data_dir:=${VTRTEMP}/lidar
         start_new_graph:=false
         use_sim_time:=true
+        path_planning.type:=stationary
 
 #      - htop # monitor hardware usage
 

--- a/launch/offline_velodyne_grizzly.launch.yaml
+++ b/launch/offline_velodyne_grizzly.launch.yaml
@@ -21,6 +21,7 @@ windows:
         data_dir:=${VTRTEMP}/lidar/
         start_new_graph:=true
         use_sim_time:=true
+        path_planning.type:=stationary
 
   - window_name: vtr_gui
     layout: main-horizontal

--- a/launch/offline_velodyne_jackal.launch.yaml
+++ b/launch/offline_velodyne_jackal.launch.yaml
@@ -21,6 +21,7 @@ windows:
         data_dir:=${VTRTEMP}/lidar
         start_new_graph:=false
         use_sim_time:=true
+        path_planning.type:=stationary
 
 #      - htop # monitor hardware usage
 

--- a/main/src/vtr_path_planning/CMakeLists.txt
+++ b/main/src/vtr_path_planning/CMakeLists.txt
@@ -35,7 +35,7 @@ include_directories(
     ${NumPy_INCLUDE_DIRS}
 )
 
-file(GLOB_RECURSE SRC src/base_path_planner.cpp)
+file(GLOB_RECURSE SRC src/base_path_planner.cpp src/stationary_planner.cpp)
 add_library(${PROJECT_NAME}_base ${SRC})
 ament_target_dependencies(${PROJECT_NAME}_base
   geometry_msgs

--- a/main/src/vtr_path_planning/include/vtr_path_planning/path_planning.hpp
+++ b/main/src/vtr_path_planning/include/vtr_path_planning/path_planning.hpp
@@ -20,3 +20,4 @@
 #include "vtr_path_planning/mpc/mpc_path_planner2.hpp"
 //#include "vtr_path_planning/mpc/mpc_path_planner.hpp"
 #include "vtr_path_planning/cbit/cbit.hpp"
+#include "vtr_path_planning/stationary_planner.hpp"

--- a/main/src/vtr_path_planning/include/vtr_path_planning/stationary_planner.hpp
+++ b/main/src/vtr_path_planning/include/vtr_path_planning/stationary_planner.hpp
@@ -26,6 +26,7 @@ namespace path_planning {
 class StationaryPlanner : public BasePathPlanner {
  public:
   PTR_TYPEDEFS(StationaryPlanner);
+  using Command = geometry_msgs::msg::Twist;
 
   static constexpr auto static_name = "stationary";
 
@@ -43,7 +44,8 @@ class StationaryPlanner : public BasePathPlanner {
 
  protected:
   Command computeCommand(RobotState& robot_state) override;
-
+  VTR_REGISTER_PATH_PLANNER_DEC_TYPE(StationaryPlanner);
+  Config::ConstPtr config_;
 
 
 };

--- a/main/src/vtr_path_planning/include/vtr_path_planning/stationary_planner.hpp
+++ b/main/src/vtr_path_planning/include/vtr_path_planning/stationary_planner.hpp
@@ -1,0 +1,52 @@
+// Copyright 2023, Autonomous Space Robotics Lab (ASRL)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * \file stationary_planner.hpp
+ * \author Alec Krawciw, Autonomous Space Robotics Lab (ASRL)
+ */
+#pragma once
+
+#include <vtr_path_planning/base_path_planner.hpp>
+
+namespace vtr {
+namespace path_planning {
+
+class StationaryPlanner : public BasePathPlanner {
+ public:
+  PTR_TYPEDEFS(StationaryPlanner);
+
+  static constexpr auto static_name = "stationary";
+
+  struct Config : public BasePathPlanner::Config {
+    PTR_TYPEDEFS(Config);
+
+    static Ptr fromROS(const rclcpp::Node::SharedPtr& node,
+                       const std::string& prefix = "path_planning");
+  };
+
+  StationaryPlanner(const Config::ConstPtr& config,
+                 const RobotState::Ptr& robot_state,
+                 const Callback::Ptr& callback);
+  ~StationaryPlanner() override;
+
+ protected:
+  Command computeCommand(RobotState& robot_state) override;
+
+
+
+};
+
+}  // namespace path_planning
+}  // namespace vtr

--- a/main/src/vtr_path_planning/src/stationary_planner.cpp
+++ b/main/src/vtr_path_planning/src/stationary_planner.cpp
@@ -1,0 +1,45 @@
+// Copyright 2023, Autonomous Space Robotics Lab (ASRL)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * \file stationary_planner.hpp
+ * \author Alec Krawciw, Autonomous Space Robotics Lab (ASRL)
+ */
+#pragma once
+
+#include <vtr_path_planning/stationary_planner.hpp>
+
+
+StationaryPlanner::Config::ConstPtr StationaryPlanner::Config::fromROS(
+    const rclcpp::Node::SharedPtr &node, const std::string &param_prefix) {
+
+  auto config = std::make_shared<StationaryPlanner::Config>();
+  auto casted_config =
+      std::static_pointer_cast<BasePlanner::Config>(config);
+  *casted_config = *BasePlanner::Config::fromROS(node, param_prefix);  // copy over base config
+
+  return config;
+}
+
+// Declare class as inherited from the BasePathPlanner
+StationaryPlanner::StationaryPlanner(const Config::ConstPtr& config,
+                               const RobotState::Ptr& robot_state,
+                               const Callback::Ptr& callback)
+    : BasePathPlanner(config, robot_state, callback), config_(config) {}
+
+StationaryPlanner::~StationaryPlanner() { stop(); }
+
+Command StationaryPlanner::computeCommand(RobotState&) { 
+    return Command();
+}

--- a/main/src/vtr_path_planning/src/stationary_planner.cpp
+++ b/main/src/vtr_path_planning/src/stationary_planner.cpp
@@ -16,18 +16,18 @@
  * \file stationary_planner.hpp
  * \author Alec Krawciw, Autonomous Space Robotics Lab (ASRL)
  */
-#pragma once
-
 #include <vtr_path_planning/stationary_planner.hpp>
 
+namespace vtr {
+namespace path_planning {
 
-StationaryPlanner::Config::ConstPtr StationaryPlanner::Config::fromROS(
-    const rclcpp::Node::SharedPtr &node, const std::string &param_prefix) {
+auto StationaryPlanner::Config::fromROS(
+    const rclcpp::Node::SharedPtr &node, const std::string &param_prefix) -> Ptr {
 
   auto config = std::make_shared<StationaryPlanner::Config>();
   auto casted_config =
-      std::static_pointer_cast<BasePlanner::Config>(config);
-  *casted_config = *BasePlanner::Config::fromROS(node, param_prefix);  // copy over base config
+      std::static_pointer_cast<BasePathPlanner::Config>(config);
+  *casted_config = *BasePathPlanner::Config::fromROS(node, param_prefix);  // copy over base config
 
   return config;
 }
@@ -40,6 +40,9 @@ StationaryPlanner::StationaryPlanner(const Config::ConstPtr& config,
 
 StationaryPlanner::~StationaryPlanner() { stop(); }
 
-Command StationaryPlanner::computeCommand(RobotState&) { 
+StationaryPlanner::Command StationaryPlanner::computeCommand(RobotState&) { 
     return Command();
 }
+
+} //path_planning
+} //vtr


### PR DESCRIPTION
There is sometimes instability with the clock and CPU usage from the MPC when debugging offline.

The class simply returns 0 velocity at all times. 

Updated the offline configs to use the stationary planner