### PR TITLE
Controller Bug Fixes 

### DIFF
--- a/main/src/vtr_path_planning/include/vtr_path_planning/cbit/cbit_path_planner.hpp
+++ b/main/src/vtr_path_planning/include/vtr_path_planning/cbit/cbit_path_planner.hpp
@@ -42,6 +42,9 @@
 // Note long term, this class should probably be inherited by the base path planner
 
 // enum for path traversal direction:
+
+using namespace vtr;
+
 enum PathDirection 
 {
     PATH_DIRECTION_REVERSE = -1,
@@ -52,8 +55,8 @@ class CBITPlanner {
     public:
         CBITConfig conf;
         std::shared_ptr<CBITPath> global_path;
-        std::shared_ptr<Node> p_start;
-        std::shared_ptr<Node> p_goal;
+        Node::Ptr p_start;
+        Node::Ptr p_goal;
         std::vector<double> path_x;
         std::vector<double> path_y;
         double sample_box_height;
@@ -64,10 +67,11 @@ class CBITPlanner {
 
         // Repair mode variables
         bool repair_mode = false; // Flag for whether or not we should resume the planner in repair mode to update the tree following a state update
-        std::shared_ptr<Node> repair_vertex;
+        Node::Ptr repair_vertex;
         double repair_g_T_old;
         double repair_g_T_weighted_old;
-        std::shared_ptr<Node> p_goal_backup;
+
+        Node::Ptr p_goal_backup;
 
 
         // For storing the most up-to-date euclidean robot pose
@@ -106,7 +110,7 @@ class CBITPlanner {
         void InitializePlanningSpace();
         void Planning(vtr::path_planning::BasePathPlanner::RobotState& robot_state, std::shared_ptr<CBITCostmap> costmap_ptr, std::shared_ptr<CBITCorridor> corridor_ptr, PathDirection path_direction);
         void ResetPlanner();
-        std::shared_ptr<Node> UpdateStateSID(int SID, vtr::tactic::EdgeTransform T_p_r);
+        std::shared_ptr<Node> UpdateStateSID(size_t SID, vtr::tactic::EdgeTransform T_p_r);
         std::vector<std::shared_ptr<Node>> SampleBox(int m);
         std::vector<std::shared_ptr<Node>> SampleFreeSpace(int m);
         double BestVertexQueueValue();

--- a/main/src/vtr_path_planning/include/vtr_path_planning/cbit/generate_pq.hpp
+++ b/main/src/vtr_path_planning/include/vtr_path_planning/cbit/generate_pq.hpp
@@ -48,8 +48,8 @@ class CBITPath {
         double delta_p_calc(Pose start_pose, Pose end_pose, double alpha); // Function for computing delta p intervals in p,q space
     // Internal function declarations
     private:
-        Eigen::Spline<double, 2> spline_path_xy(std::vector<Pose> input_path); // Processes the input discrete path into a cubic spline
-        Eigen::Spline<double, 2> spline_path_xz_yz(std::vector<Pose> input_path); // Processes the input discrete path into a cubic spline
+        Eigen::Spline<double, 2> spline_path_xy(const std::vector<Pose> &input_path); // Processes the input discrete path into a cubic spline
+        Eigen::Spline<double, 2> spline_path_xz_yz(const std::vector<Pose> &input_path); // Processes the input discrete path into a cubic spline
 
         double radius_of_curvature(double dist, Eigen::Spline<double, 2> spline); // Calculates the radius of curvature using the spline at a given distance along the spline
        

--- a/main/src/vtr_path_planning/include/vtr_path_planning/cbit/utils.hpp
+++ b/main/src/vtr_path_planning/include/vtr_path_planning/cbit/utils.hpp
@@ -59,17 +59,20 @@ class Pose {
 
 class Node {
     public:
+        using Ptr = std::shared_ptr<Node>;
+
         double p;
         double q;
         double z; // experimental
         double g_T = NAN;
         double g_T_weighted = NAN;
-        std::shared_ptr<Node> parent; // Shared pointer method (safer) // NOTE: Shared pointers initialize to null
-        std::shared_ptr<Node> child; // Shared pointer method (safer)
+        Node::Ptr parent; // Shared pointer method (safer) // NOTE: Shared pointers initialize to null
+        Node::Ptr child; // Shared pointer method (safer)
         bool worm_hole = false;
         Node(double p_in, double q_in) // Node constructor
         : p{p_in}
         , q{q_in}
+        , z{0}
         {
         }
 

--- a/main/src/vtr_path_planning/include/vtr_path_planning/mpc/custom_loss_functions.hpp
+++ b/main/src/vtr_path_planning/include/vtr_path_planning/mpc/custom_loss_functions.hpp
@@ -53,7 +53,7 @@ class L2WeightedLossFunc : public BaseLossFunc {
    * \brief Weight for iteratively reweighted least-squares (influence function
    * div. by error)
    */
-  double weight(double whitened_error_norm) const override { return weight_val; }
+  double weight(double) const override { return weight_val; }
 
 };
 

--- a/main/src/vtr_path_planning/include/vtr_path_planning/mpc/mpc_path_planner.hpp
+++ b/main/src/vtr_path_planning/include/vtr_path_planning/mpc/mpc_path_planner.hpp
@@ -87,7 +87,7 @@ struct MPCResult SolveMPC(const MPCConfig& config);
 struct PoseResultTracking GenerateTrackingReference(std::shared_ptr<std::vector<Pose>> cbit_path_ptr,  std::tuple<double, double, double, double, double, double> robot_pose, int K, double DT, double VF);
 
 // Helper function for generating reference measurements poses from a discrete path to use for tracking the path at a desired forward velocity
-struct PoseResultHomotopy GenerateHomotopyReference(std::shared_ptr<CBITPath> global_path_ptr, std::shared_ptr<CBITCorridor> corridor_ptr, std::tuple<double, double, double, double, double, double> robot_pose, int K, double DT, double VF, int current_sid, std::vector<double> p_interp_vec);
+struct PoseResultHomotopy GenerateHomotopyReference(std::shared_ptr<CBITPath> global_path_ptr, std::shared_ptr<CBITCorridor> corridor_ptr, std::tuple<double, double, double, double, double, double> robot_pose, const std::vector<double> &p_interp_vec);
 
 // Helper function for post-processing and saturating the velocity command
 Eigen::Matrix<double, 2, 1> SaturateVel(Eigen::Matrix<double, 2, 1> applied_vel, double v_lim, double w_lim);

--- a/main/src/vtr_path_planning/include/vtr_path_planning/mpc/speed_scheduler.hpp
+++ b/main/src/vtr_path_planning/include/vtr_path_planning/mpc/speed_scheduler.hpp
@@ -24,4 +24,4 @@
 #include "vtr_path_planning/cbit/generate_pq.hpp"
 
 
-double ScheduleSpeed(const std::vector<double>& disc_path_curvature_xy, const std::vector<double>& disc_path_curvature_xz_yz, double VF, int curr_sid, double planar_curv_weight, double profile_curv_weight, double eop_weight, double horizon_step_size, double min_vel);
+double ScheduleSpeed(const std::vector<double>& disc_path_curvature_xy, const std::vector<double>& disc_path_curvature_xz_yz, double VF, unsigned curr_sid, double planar_curv_weight, double profile_curv_weight, double eop_weight, double horizon_step_size, double min_vel);

--- a/main/src/vtr_path_planning/src/cbit/cbit.cpp
+++ b/main/src/vtr_path_planning/src/cbit/cbit.cpp
@@ -21,7 +21,7 @@
 #include "vtr_path_planning/mpc/mpc_path_planner.hpp"
 
 #include <tf2/convert.h>
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 
 namespace vtr {
 namespace path_planning {
@@ -363,7 +363,7 @@ auto CBIT::computeCommand(RobotState& robot_state) -> Command {
 
     // Storing sequences of costmaps for temporal filtering purposes
     // For the first x iterations, fill the obstacle vector
-    if (costmap_ptr->obs_map_vect.size() < config_->costmap_history)
+    if (costmap_ptr->obs_map_vect.size() < (unsigned) config_->costmap_history)
     {
       costmap_ptr->obs_map_vect.push_back(obs_map);
       costmap_ptr->T_c_w_vect.push_back(costmap_ptr->T_c_w);
@@ -497,19 +497,19 @@ auto CBIT::computeCommand(RobotState& robot_state) -> Command {
     std::vector<double> q_interp_vec = ref_tracking_result.q_interp_vec;
 
     // Synchronized Tracking/Teach Reference Poses For Homotopy Guided MPC:
-    auto ref_homotopy_result = GenerateHomotopyReference(global_path_ptr, corridor_ptr, robot_pose, K,  DT, VF, curr_sid, p_interp_vec);
+    auto ref_homotopy_result = GenerateHomotopyReference(global_path_ptr, corridor_ptr, robot_pose, p_interp_vec);
     auto homotopy_poses = ref_homotopy_result.poses;
     bool point_stabilization = ref_homotopy_result.point_stabilization;
     std::vector<double> barrier_q_left = ref_homotopy_result.barrier_q_left;
     std::vector<double> barrier_q_right = ref_homotopy_result.barrier_q_right;
+
     std::vector<lgmath::se3::Transformation> tracking_pose_vec;
-    for (int i = 0; i<tracking_poses.size(); i++)
-    {
+    for (size_t i = 0; i < tracking_poses.size(); i++) {
       tracking_pose_vec.push_back(tracking_poses[i].inverse());
     }
+
     std::vector<lgmath::se3::Transformation> homotopy_pose_vec;
-    for (int i = 0; i<homotopy_poses.size(); i++)
-    {
+    for (size_t i = 0; i < homotopy_poses.size(); i++) {
       homotopy_pose_vec.push_back(homotopy_poses[i].inverse());
     }
 

--- a/main/src/vtr_path_planning/src/cbit/cbit_path_planner.cpp
+++ b/main/src/vtr_path_planning/src/cbit/cbit_path_planner.cpp
@@ -21,18 +21,21 @@
 
 #include "vtr_path_planning/cbit/cbit_path_planner.hpp"
 
+using namespace vtr;
+using namespace vtr::path_planning;
 
 namespace {
 // Function for converting Transformation matrices into se(2) [x, y, z, roll, pitch, yaw]
 // Note we also might be able to do this with just lgmaths tran2vec operation?
 inline std::tuple<double, double, double, double, double, double> T2xyzrpy(
-    const vtr::tactic::EdgeTransform& T) {
+    const tactic::EdgeTransform& T) {
   const auto Tm = T.matrix();
   return std::make_tuple(Tm(0, 3), Tm(1, 3), Tm(2,3), std::atan2(Tm(2, 1), Tm(2, 2)), std::atan2(-1.0*Tm(2, 0), sqrt(pow(Tm(2, 1),2) + pow(Tm(2, 2),2))), std::atan2(Tm(1, 0), Tm(0, 0)));
 }
 }
 
-auto CBITPlanner::getChainInfo(vtr::path_planning::BasePathPlanner::RobotState& robot_state) -> ChainInfo {
+
+auto CBITPlanner::getChainInfo(BasePathPlanner::RobotState& robot_state) -> ChainInfo {
   auto& chain = *robot_state.chain;
   auto lock = chain.guard();
   const auto stamp = chain.leaf_stamp();
@@ -44,7 +47,7 @@ auto CBITPlanner::getChainInfo(vtr::path_planning::BasePathPlanner::RobotState& 
 }
 
 // Class Constructor:
-CBITPlanner::CBITPlanner(CBITConfig conf_in, std::shared_ptr<CBITPath> path_in, vtr::path_planning::BasePathPlanner::RobotState& robot_state, std::shared_ptr<std::vector<Pose>> path_ptr, std::shared_ptr<CBITCostmap> costmap_ptr, std::shared_ptr<CBITCorridor> corridor_ptr, std::shared_ptr<bool> solution_ptr, std::shared_ptr<double> width_ptr, PathDirection path_direction)
+CBITPlanner::CBITPlanner(CBITConfig conf_in, std::shared_ptr<CBITPath> path_in, BasePathPlanner::RobotState& robot_state, std::shared_ptr<std::vector<Pose>> path_ptr, std::shared_ptr<CBITCostmap> costmap_ptr, std::shared_ptr<CBITCorridor> corridor_ptr, std::shared_ptr<bool> solution_ptr, std::shared_ptr<double> width_ptr, PathDirection path_direction)
 { 
   // Setting random seed
   srand((unsigned int)time(NULL));
@@ -133,7 +136,7 @@ void CBITPlanner::ResetPlanner()
 
 
 // Main planning function
-void CBITPlanner::Planning(vtr::path_planning::BasePathPlanner::RobotState& robot_state, std::shared_ptr<CBITCostmap> costmap_ptr, std::shared_ptr<CBITCorridor> corridor_ptr, PathDirection path_direction)
+void CBITPlanner::Planning(BasePathPlanner::RobotState& robot_state, std::shared_ptr<CBITCostmap> costmap_ptr, std::shared_ptr<CBITCorridor> corridor_ptr, PathDirection path_direction)
 {
   double prev_path_cost = INFINITY;
   int compute_time = 0;
@@ -174,7 +177,7 @@ void CBITPlanner::Planning(vtr::path_planning::BasePathPlanner::RobotState& robo
           {
           // If we ever become unlocalized, I think we just need to break, then set a flag to exit the outer loop
           // This also triggers after we reach end of path and effectively shuts down the planner
-          bool localization_flag = false;
+          localization_flag = false;
           CLOG(WARNING, "cbit_planner.path_planning") << "Localization was Lost, Exiting Inner Planning Loop";
           break;
         }
@@ -230,7 +233,7 @@ void CBITPlanner::Planning(vtr::path_planning::BasePathPlanner::RobotState& robo
 
        // Alternative: Take all points in a radius of 2.0m around the new robot state (only if they are a ahead though)
         double sample_dist;
-        for (int i = 0; i < tree.V.size(); i++)
+        for (size_t i = 0; i < tree.V.size(); i++)
         {
           //tree.QV2.insert(std::pair<double, std::shared_ptr<Node>>((tree.V[i]->g_T_weighted + h_estimated_admissible(*tree.V[i], *p_goal)), tree.V[i]));
           sample_dist = calc_dist(*(tree.V[i]), *p_goal);
@@ -345,7 +348,7 @@ void CBITPlanner::Planning(vtr::path_planning::BasePathPlanner::RobotState& robo
           // Vertex Prune (maintain only vertices to the right of the collision free vertex)
           std::vector<std::shared_ptr<Node>> pruned_vertex_tree;
           pruned_vertex_tree.reserve(tree.V.size());
-          for (int i =0; i<tree.V.size(); i++)
+          for (size_t i =0; i < tree.V.size(); i++)
           {
             if (tree.V[i]->p >= col_free_vertex->p)
             {
@@ -358,7 +361,7 @@ void CBITPlanner::Planning(vtr::path_planning::BasePathPlanner::RobotState& robo
           // Edge Prune (maintain only edges to the right of the collision free vertex)
           std::vector<std::tuple<std::shared_ptr<Node>, std::shared_ptr<Node>>>  pruned_edge_tree;
           pruned_edge_tree.reserve(tree.E.size());
-          for (int i = 0; i <tree.E.size(); i++)
+          for (size_t i = 0; i < tree.E.size(); i++)
           {
             if (std::get<1>(tree.E[i])->p >= col_free_vertex->p)
             {
@@ -428,16 +431,17 @@ void CBITPlanner::Planning(vtr::path_planning::BasePathPlanner::RobotState& robo
         CLOG(INFO, "cbit_planner.path_planning") << "Sample Free Space";
       }
 
+      //TODO Use iterator to move vectors around!
     
       // Backup the old tree:
       tree.V_Old.clear();
       tree.E_Old.clear();
-      for (int i = 0; i < tree.V.size(); i++)
+      for (size_t i = 0; i < tree.V.size(); i++)
       {
         tree.V_Old.push_back((tree.V[i]));
       }
 
-      for (int i = 0; i < tree.E.size(); i++)
+      for (size_t i = 0; i < tree.E.size(); i++)
       {
         tree.E_Old.push_back(tree.E[i]);
       }
@@ -446,7 +450,7 @@ void CBITPlanner::Planning(vtr::path_planning::BasePathPlanner::RobotState& robo
       std::random_device rd;     // Only used once to initialise (seed) engine
       std::mt19937 rng(rd());    // Random-number engine used (Mersenne-Twister in this case)
       std::uniform_int_distribution<int> uni(1,100); // Guaranteed unbiased 
-      for (int i = 0; i < tree.V.size(); i++)
+      for (size_t i = 0; i < tree.V.size(); i++)
       {
         auto random_integer = uni(rng);
         random_integer = static_cast <double>(random_integer);
@@ -555,7 +559,7 @@ void CBITPlanner::Planning(vtr::path_planning::BasePathPlanner::RobotState& robo
           {
             // If the end point is not in the tree, it must have come from a random sample.
             // Remove it from the samples, add it to the vertex tree and vertex queue:
-            for (int i = 0; i < samples.size(); i++)
+            for (size_t i = 0; i < samples.size(); i++)
             {
               if (samples[i] == xm)
               {
@@ -702,15 +706,15 @@ std::vector<std::shared_ptr<Node>> CBITPlanner::SampleFreeSpace(int m)
     // uniformly sample the configuration space
     double rand_p = p_zero + (rand() / (RAND_MAX / (p_max-p_zero)));
     double rand_q = (-1.0*q_max) + (rand() / (RAND_MAX / (q_max- (-1.0*q_max))));
-    Node node(rand_p, rand_q);
+    auto node = std::make_shared<Node>(rand_p, rand_q);
 
-    if (costmap_col(curve_to_euclid(node)))
+    if (costmap_col(curve_to_euclid(*node)))
     {
       continue;
     }
     else
     {
-      new_samples.push_back(std::make_shared<Node> (node));
+      new_samples.push_back(node);
       ind++; // only increment if we do not have a collision
     }
   }
@@ -749,7 +753,7 @@ void CBITPlanner::Prune(double c_best, double c_best_weighted)
     double vertex_cost;
     double p;
     double q;
-    for (int i = 0; i < path_x.size(); i++)
+    for (size_t i = 0; i < path_x.size(); i++)
     {
       p = path_x[i];
       q = path_y[i];
@@ -769,7 +773,7 @@ void CBITPlanner::Prune(double c_best, double c_best_weighted)
   // I think for vectors, its probably faster to just copy the samples to a new pointer vector which do satisfy the constraint,
   // Then overwrite the samples, instead of doing many many deletions
   std::vector<std::shared_ptr<Node>> samples_pruned;
-  for (int i = 0; i < samples.size(); i++)
+  for (size_t i = 0; i < samples.size(); i++)
   {
     if (f_estimated(*samples[i], *p_start, *p_goal, conf.alpha) < cost_threshold)// Also handles inf flagged values
     {
@@ -780,7 +784,7 @@ void CBITPlanner::Prune(double c_best, double c_best_weighted)
   // We also check the tree and add samples for unconnected vertices back to the sample set
   std::vector<std::shared_ptr<Node>> vertex_pruned;
   int vertices_size = tree.V.size(); 
-  for (int i = 0; i < vertices_size; i++)
+  for (size_t i = 0; i < vertices_size; i++)
   {
     if (tree.V[i]->g_T_weighted == INFINITY)
     {
@@ -799,7 +803,7 @@ void CBITPlanner::Prune(double c_best, double c_best_weighted)
 
   // Similar Prune of the Edges
   std::vector<std::tuple<std::shared_ptr<Node>, std::shared_ptr<Node>>>  edge_pruned;
-  for (int i = 0; i <tree.E.size(); i++)
+  for (size_t i = 0; i <tree.E.size(); i++)
   {
     // In the below condition, I also include the prune of vertices with inf cost to come values
     if ((f_estimated(*std::get<0>(tree.E[i]), *p_start, *p_goal, conf.alpha) <= cost_threshold) && (f_estimated(*std::get<1>(tree.E[i]), *p_start, *p_goal, conf.alpha) <= cost_threshold))
@@ -813,7 +817,7 @@ void CBITPlanner::Prune(double c_best, double c_best_weighted)
 
 
 // New Simpler State Update function that instead uses the robots localization frame SID to help find the robot p,q space state
-std::shared_ptr<Node> CBITPlanner::UpdateStateSID(int SID, vtr::tactic::EdgeTransform T_p_r)
+Node::Ptr CBITPlanner::UpdateStateSID(size_t SID, vtr::tactic::EdgeTransform T_p_r)
 {
   // Find the corresponding global pose p,q value at the current SID (which should be just behind the actual current state)
   double current_pq_sid_p = global_path->p[SID];
@@ -824,7 +828,7 @@ std::shared_ptr<Node> CBITPlanner::UpdateStateSID(int SID, vtr::tactic::EdgeTran
   // The length of the subset is determined by the configuration parameter lookahead distance and the desired discretization
   // Use the SID values to help predict how far we should look ahead look ahead without falling into false minim on crossing paths.
   double lookahead_range = (*p_goal).p + conf.roc_lookahead; //default value from config
-  for (int ID = SID; ID < global_path->p.size(); ID += 1)
+  for (size_t ID = SID; ID < global_path->p.size(); ID += 1)
   {
     if ((*p_goal).p < global_path->p[ID])
     {
@@ -838,12 +842,12 @@ std::shared_ptr<Node> CBITPlanner::UpdateStateSID(int SID, vtr::tactic::EdgeTran
   }
 
   // calc q_min
-  double q_min = (*q_max_ptr);
+  double q_min = *q_max_ptr;
   double q;
   Node closest_pt;
-  int closest_pt_ind;
+  size_t closest_pt_ind;
 
-  for (int i=0; i<euclid_subset.size(); i++)
+  for (size_t i = 0; i < euclid_subset.size(); i++)
   {
     double dx = new_state->x - euclid_subset[i].p;
     double dy = new_state->y - euclid_subset[i].q;
@@ -992,8 +996,7 @@ std::shared_ptr<Node> CBITPlanner::BestInVertexQueue()
   }
   // New multimap implementation of this:
   std::multimap<double, std::shared_ptr<Node>>::iterator itr = tree.QV2.begin();
-  std::shared_ptr<Node> best_vertex = itr -> second;
-  double min_vertex_cost = itr -> first;
+  std::shared_ptr<Node> best_vertex = itr->second;
   tree.QV2.erase(itr);
 
   return best_vertex;
@@ -1005,7 +1008,7 @@ void CBITPlanner::ExpandVertex(std::shared_ptr<Node> v)
 {
   // Note its easier in c++ to remove the vertex from the queue in the bestinvertexqueue function instead
   // Find nearby samples and filter by heuristic potential
-  for (int i = 0; i < samples.size(); i++)
+  for (size_t i = 0; i < samples.size(); i++)
   {
     if ((calc_dist(*samples[i], *v) <= conf.initial_exp_rad) && ((g_estimated_admissible(*v, *p_start) + calc_weighted_dist(*v, *samples[i], conf.alpha) + h_estimated_admissible(*samples[i], *p_goal)) <= p_goal->g_T_weighted))
     {
@@ -1019,7 +1022,7 @@ void CBITPlanner::ExpandVertex(std::shared_ptr<Node> v)
   }  
 
   // find nearby vertices and filter by heuristic potential
-  for (int i = 0; i < tree.V.size(); i++)
+  for (size_t i = 0; i < tree.V.size(); i++)
   {
     if ((calc_dist(*tree.V[i], *v) <= conf.initial_exp_rad) && ((g_estimated_admissible(*v, *p_start) + calc_weighted_dist(*v, *tree.V[i], conf.alpha) + h_estimated_admissible(*tree.V[i], *p_goal)) < p_goal->g_T_weighted) && ((v->g_T_weighted + calc_weighted_dist(*v, *tree.V[i], conf.alpha)) < tree.V[i]->g_T_weighted))
     {
@@ -1045,17 +1048,15 @@ std::tuple<std::shared_ptr<Node>, std::shared_ptr<Node>> CBITPlanner::BestInEdge
 
   // Equivalent code using multimaps:
   std::multimap<double, std::tuple<std::shared_ptr<Node>, std::shared_ptr<Node>>>::iterator itr = tree.QE2.begin();
-  double min_edge_cost = itr -> first;
   std::tuple<std::shared_ptr<Node>, std::shared_ptr<Node>> edge_tuple = itr -> second;
   tree.QE2.erase(itr);
   return edge_tuple;
 }
 
 
-std::tuple<std::vector<double>, std::vector<double>> CBITPlanner::ExtractPath(vtr::path_planning::BasePathPlanner::RobotState& robot_state, std::shared_ptr<CBITCostmap> costmap_ptr)
+std::tuple<std::vector<double>, std::vector<double>> CBITPlanner::ExtractPath(BasePathPlanner::RobotState& robot_state, std::shared_ptr<CBITCostmap> costmap_ptr)
 {
   int inf_loop_counter = 0;
-  bool debug_display = false;
 
   Node node = *p_goal;
   
@@ -1065,12 +1066,7 @@ std::tuple<std::vector<double>, std::vector<double>> CBITPlanner::ExtractPath(vt
   while(node.parent != nullptr)
   {
     inf_loop_counter = inf_loop_counter + 1;
-    if (inf_loop_counter >= 5000)
-    {
-      debug_display = true;
-    }
-    if (debug_display == true)
-    {
+    if (inf_loop_counter >= 5000) {
       CLOG(DEBUG, "cbit_planner.path_planning") << "Something Went Wrong - Infinite Loop Detected, Initiating Hard Reset:";
     }
     node = *node.parent;
@@ -1111,7 +1107,7 @@ std::vector<Pose>  CBITPlanner::ExtractEuclidPath()
     node_list.push_back(node);
   }
 
-  for (int i=0; i < (node_list.size()-1); i++)
+  for (size_t i=0; i < (node_list.size()-1); i++)
   {
     Node start = node_list[i];
     Node end = node_list[i+1];
@@ -1130,14 +1126,14 @@ std::vector<Pose>  CBITPlanner::ExtractEuclidPath()
       double b = start.q - (slope * start.p);
       p_disc = linspace(start.p, end.p, discretization);
       q_disc.reserve(p_disc.size());
-      for (int i=0; i < p_disc.size(); i++)
+      for (size_t i=0; i < p_disc.size(); i++)
       {
         q_disc.push_back((p_disc[i] * slope + b));
       }
     }
 
     // Once we have built the discretized vectors, loop through them, convert each point to Euclidean space and store it in the Euclidean path vector
-    for (int i=0; i < p_disc.size(); i ++)
+    for (size_t i=0; i < p_disc.size(); i ++)
     {
       Node euclid_pt = curve_to_euclid(Node(p_disc[i], q_disc[i]));
       path_x.push_back(euclid_pt.p);
@@ -1159,7 +1155,7 @@ std::vector<Pose>  CBITPlanner::ExtractEuclidPath()
 
   // Temporarily reshaping the output into the form we need (vector of poses)
   std::vector<Pose> pose_vector;
-  for (int i = 0; i<path_x.size(); i++)
+  for (size_t i = 0; i < path_x.size(); i++)
   {
     Pose next_pose = Pose(path_x[i], path_y[i], path_z[i], 0.0, 0.0, path_yaw[i]);
     next_pose.p = path_p[i];
@@ -1188,7 +1184,7 @@ std::shared_ptr<Node> CBITPlanner::col_check_path_v2(double max_lookahead_p)
   // find the first vertex which results in a collision (curv_path is generated from left to right, so we should search in reverse)
   std::shared_ptr<Node> col_free_vertex = nullptr;
 
-  for (int i = curv_path.size()-1; i>=0; i--)
+  for (long i = curv_path.size()-1; i >= 0; i--)
   {
     Node vertex = *curv_path[i];
     // If the vertex in the path is outside of our sliding window then skip it
@@ -1220,7 +1216,7 @@ std::shared_ptr<Node> CBITPlanner::col_check_path_v2(double max_lookahead_p)
 bool CBITPlanner::edge_in_tree_v2(std::shared_ptr<Node> v, std::shared_ptr<Node> x)
 {
   int edges_size = tree.E.size();
-  for (int i = 0; i < edges_size; i++ )
+  for (size_t i = 0; i < edges_size; i++ )
   {
     // Alternative way to do this using node addresses
     if ((std::get<0>(tree.E[i]) == v) && (std::get<1>(tree.E[i]) == x))
@@ -1234,19 +1230,16 @@ bool CBITPlanner::edge_in_tree_v2(std::shared_ptr<Node> v, std::shared_ptr<Node>
 
 
 // Function for checking whether a node lives in the Vertex tree, updated to use address matching (safer)
-bool CBITPlanner::node_in_tree_v2(std::shared_ptr<Node>  x)
+bool CBITPlanner::node_in_tree_v2(std::shared_ptr<Node> x)
 {
-  int vertices_size = tree.V.size();
-  for (int i = 0; i < vertices_size; i++ )
+  for (size_t i = 0; i < tree.V.size(); i++ )
   {
-      
     if (x == tree.V[i])
     {
         return true;
     }
   }
   return false;
-  
 }
 
 
@@ -1342,13 +1335,9 @@ bool CBITPlanner::costmap_col_tight(Node node)
 
   // Check to see if the point is in the obstacle map
   // We need to use a try/catch in this metod as if the key value pair doesnt exist (it usually wont) we catch an out of range error
-  try 
-  {
-  // Block of code to try
+  try  {
     grid_value = cbit_costmap_ptr->obs_map.at(std::pair<float, float> (x_key, y_key));
-  }
-  catch (std::out_of_range) 
-  {
+  } catch (std::out_of_range &e) {
     grid_value = 0.0;
   }
 
@@ -1376,22 +1365,16 @@ bool CBITPlanner::costmap_col(Node node)
   float grid_value;
 
   // Check to see if the point is in the obstacle map
-  // If it isnt in the map we will catch an out of range error
-  try 
-  {
+  // If it isn't in the map we will catch an out of range error
+  try {
       grid_value = cbit_costmap_ptr->obs_map.at(std::pair<float, float> (x_key, y_key));
-  }
-  
-  catch (std::out_of_range) 
-  {
-
+  } catch (std::out_of_range &e) {
     grid_value = 0.0;
   }
 
-  if (grid_value > 0.0)
-    {
-      return true;
-    }
+  if (grid_value > 0.0) {
+    return true;
+  }
 
   // If we make it here, return false for no collision
   return false;
@@ -1423,9 +1406,9 @@ bool CBITPlanner::discrete_collision(std::vector<std::vector<double>> obs, doubl
     q_test.push_back(end.q);
 
     // Loop through the test curvilinear points, convert to euclid, collision check obstacles
-    for (int i = 0; i < p_test.size(); i++)
+    for (size_t i = 0; i < p_test.size(); i++)
     {
-        Node curv_pt = Node(p_test[i], q_test[i]);
+        Node curv_pt {p_test[i], q_test[i]};
         Node euclid_pt = curve_to_euclid(curv_pt);
         if (costmap_col_tight(euclid_pt))
         {

--- a/main/src/vtr_path_planning/src/cbit/cbit_plotting.cpp
+++ b/main/src/vtr_path_planning/src/cbit/cbit_plotting.cpp
@@ -42,7 +42,7 @@ void initialize_plot()
 
 // Function for plotting all the edges in the current tree (Called at the conclusion of each batch)
 // Note this will also get triggered following state updates and repairs as well
-void plot_tree(Tree tree, Node robot_pq, std::vector<double> path_p, std::vector<double> path_q, std::vector<std::shared_ptr<Node>> samples)
+void plot_tree(Tree tree, Node robot_pq, std::vector<double> path_p, std::vector<double> path_q, std::vector<std::shared_ptr<Node>>&)
 {
     // Clear the figure
     matplotlibcpp::clf();
@@ -58,7 +58,7 @@ void plot_tree(Tree tree, Node robot_pq, std::vector<double> path_p, std::vector
 
 
     // Iterate through the current tree, plot each edge
-    for (int i = 0; i < tree.E.size(); i++)
+    for (size_t i = 0; i < tree.E.size(); i++)
     {
         std::shared_ptr<Node> vm = std::get<0>(tree.E[i]);
         std::shared_ptr<Node> xm = std::get<1>(tree.E[i]);
@@ -73,7 +73,7 @@ void plot_tree(Tree tree, Node robot_pq, std::vector<double> path_p, std::vector
 
     // Plot the current path solution
     // Invert the q values
-    for (int j= 0; j < path_q.size(); j++)
+    for (size_t j= 0; j < path_q.size(); j++)
     {
         path_q[j] = path_q[j] * -1;
     }

--- a/main/src/vtr_path_planning/src/cbit/generate_pq.cpp
+++ b/main/src/vtr_path_planning/src/cbit/generate_pq.cpp
@@ -106,18 +106,17 @@ double CBITPath::delta_p_calc(Pose start_pose, Pose end_pose, double alpha)
 Eigen::Spline<double, 2> CBITPath::spline_path_xy(const std::vector<Pose> &input_path)
 {
     std::vector<Eigen::Vector2d> valid_points;
+    int spacing = (input_path.size() < 20) ? input_path.size() / 4 : 5;
+    if (spacing == 0)
+        spacing = 1;
 
     // Usually use every fifth point. 
-    // If the input path is shorter than 5 points use a linear fit between the start and end
+    // If the input path is shorter than 20 choose a spacing between 1 and 5
 
-    if (input_path.size() < 5){
-        valid_points.push_back(Eigen::Vector2d(input_path[0].x, input_path[0].y));
-        valid_points.push_back(Eigen::Vector2d(input_path[input_path.size()-1].x, input_path[input_path.size()-1].y));
-    } else {
-        for (size_t i = 0; i < input_path.size(); i++) {
-            if (i % 5 == 0) {
-                valid_points.push_back(Eigen::Vector2d(input_path[i].x, input_path[i].y));
-            }
+    
+    for (size_t i = 0; i < input_path.size(); i++) {
+        if (i % spacing == 0) {
+            valid_points.push_back(Eigen::Vector2d(input_path[i].x, input_path[i].y));
         }
     }
 
@@ -143,16 +142,14 @@ Eigen::Spline<double, 2> CBITPath::spline_path_xz_yz(const std::vector<Pose> &in
     std::vector<Eigen::Vector2d> valid_points;
 
     // Usually use every fifth point. 
-    // If the input path is shorter than 5 points use a linear fit between the start and end
+    // If the input path is shorter than 20 choose a spacing between 1 and 5
+    int spacing = (input_path.size() < 20) ? input_path.size() / 4 : 5;
+    if (spacing == 0)
+        spacing = 1;
 
-    if (input_path.size() < 5){
-        valid_points.push_back(Eigen::Vector2d(input_path[0].x, input_path[0].y));
-        valid_points.push_back(Eigen::Vector2d(input_path[input_path.size()-1].x, input_path[input_path.size()-1].y));
-    } else {
-        for (size_t i = 0; i < input_path.size(); i++) {
-            if (i % 5 == 0) {
-                valid_points.push_back(Eigen::Vector2d(sqrt((input_path[i].x * input_path[i].x) + (input_path[i].y * input_path[i].y)), input_path[i].z));
-            }
+    for (size_t i = 0; i < input_path.size(); i++) {
+        if (i % spacing == 0) {
+            valid_points.push_back(Eigen::Vector2d(sqrt((input_path[i].x * input_path[i].x) + (input_path[i].y * input_path[i].y)), input_path[i].z));
         }
     }
 

--- a/main/src/vtr_path_planning/src/cbit/visualization_utils.cpp
+++ b/main/src/vtr_path_planning/src/cbit/visualization_utils.cpp
@@ -192,7 +192,7 @@ void VisualizationUtils::visualize(
         pose_array_msg.header.frame_id = "world";
 
         // fill the PoseArray with some sample poses
-        for (int i = 0; i < tracking_pose_vec.size(); i++) {
+        for (size_t i = 0; i < tracking_pose_vec.size(); i++) {
             geometry_msgs::msg::Pose pose;
             auto T1 = tracking_pose_vec[i].matrix();
             pose.position.x = T1(0,3);
@@ -211,7 +211,7 @@ void VisualizationUtils::visualize(
         pose_array_msg.header.frame_id = "world";
 
         // fill the PoseArray with some sample poses
-        for (int i = 0; i < homotopy_pose_vec.size(); i++) {
+        for (size_t i = 0; i < homotopy_pose_vec.size(); i++) {
             geometry_msgs::msg::Pose pose;
             auto T2 = homotopy_pose_vec[i].matrix();
             pose.position.x = T2(0,3);

--- a/main/src/vtr_path_planning/src/mpc/mpc_path_planner.cpp
+++ b/main/src/vtr_path_planning/src/mpc/mpc_path_planner.cpp
@@ -106,7 +106,7 @@ struct MPCResult SolveMPC(const MPCConfig& config)
     vel_states.push_back(v0);
 
     // Set the remaining states using a warm start from the cbit solution
-    for (int i=1; i<K; i++)
+    for (int i=1; i < K; i++)
     {
         pose_states.push_back(tracking_reference_poses[i]); // New initialization - use the reference measurements from the cbit solution as our initialization - the first one is the same as our initial state
         vel_states.push_back(v0);
@@ -302,7 +302,7 @@ struct MPCResult SolveMPC(const MPCConfig& config)
 
       // if we do detect nans, return the mpc_poses as all being the robots current pose (not moving across the horizon as we should be stopped)
       std::vector<lgmath::se3::Transformation> mpc_poses;
-      for (int i = 0; i<pose_state_vars.size(); i++)
+      for (size_t i = 0; i < pose_state_vars.size(); i++)
       {
         mpc_poses.push_back(T0);
       }
@@ -349,7 +349,7 @@ struct MPCResult SolveMPC(const MPCConfig& config)
 
       // if we do detect nans, return the mpc_poses as all being the robots current pose (not moving across the horizon as we should be stopped)
       std::vector<lgmath::se3::Transformation> mpc_poses;
-      for (int i = 0; i<pose_state_vars.size(); i++)
+      for (size_t i = 0; i < pose_state_vars.size(); i++)
       {
         mpc_poses.push_back(T0);
       }
@@ -361,7 +361,7 @@ struct MPCResult SolveMPC(const MPCConfig& config)
     {
     // Store the sequence of resulting mpc prediction horizon poses for visualization
     std::vector<lgmath::se3::Transformation> mpc_poses;
-    for (int i = 0; i<pose_state_vars.size(); i++)
+    for (size_t i = 0; i < pose_state_vars.size(); i++)
     {
       mpc_poses.push_back(pose_state_vars[i]->value().inverse());
     }
@@ -401,7 +401,7 @@ struct PoseResultTracking GenerateTrackingReference(std::shared_ptr<std::vector<
     std::vector<double> cbit_p;
     cbit_p.reserve(cbit_path.size());
     cbit_p.push_back(0.0);
-    for (int i = 0; i < (cbit_path.size()-2); i++) // the last value of vector is size()-1, so second to last will be size-2
+    for (size_t i = 0; i < (cbit_path.size()-2); i++) // the last value of vector is size()-1, so second to last will be size-2
     { 
       // calculate the p value for the point
       p_dist = sqrt((((cbit_path)[i].x - (cbit_path)[i+1].x) * ((cbit_path)[i].x - (cbit_path)[i+1].x)) + (((cbit_path)[i].y - (cbit_path)[i+1].y) * ((cbit_path)[i].y - (cbit_path)[i+1].y)));
@@ -448,7 +448,7 @@ struct PoseResultTracking GenerateTrackingReference(std::shared_ptr<std::vector<
     // Iterate through the p_measurements and interpolate euclidean poses from the cbit_path and the corresponding cbit_p values
     // Note this could probably just be combined in the previous loop too
     bool point_stabilization = false;
-    for (int i = 0; i < p_meas_vec.size(); i++)
+    for (size_t i = 0; i < p_meas_vec.size(); i++)
     {
       // handle end of path case:
       // if the p meas we would have needed exceeds the final measurement pose, set it equal to our last p value in the path
@@ -473,8 +473,7 @@ struct PoseResultTracking GenerateTrackingReference(std::shared_ptr<std::vector<
 
 
 // For generating VT&R teach path poses used in the corridor mpc (new version which directly uses the interpolated p measurements from the cbit path trajectory tracking)
-struct PoseResultHomotopy GenerateHomotopyReference(std::shared_ptr<CBITPath> global_path_ptr, std::shared_ptr<CBITCorridor> corridor_ptr, std::tuple<double, double, double, double, double, double> robot_pose, int K, double DT, double VF, int current_sid, std::vector<double> p_interp_vec)
-{
+struct PoseResultHomotopy GenerateHomotopyReference(std::shared_ptr<CBITPath> global_path_ptr, std::shared_ptr<CBITCorridor> corridor_ptr, std::tuple<double, double, double, double, double, double> robot_pose, const std::vector<double> &p_interp_vec) {
     // Set point stabilization, but just note if we use this function in the cbit.cpp file we need to use the Tracking reference pose point stabilization instead
     bool point_stabilization = false;
 
@@ -490,7 +489,7 @@ struct PoseResultHomotopy GenerateHomotopyReference(std::shared_ptr<CBITPath> gl
     std::vector<lgmath::se3::Transformation> tracking_reference_poses;
 
     // Iterate through the interpolated p_measurements and make interpolate euclidean poses from the teach path
-    for (int i = 0; i < p_interp_vec.size(); i++)
+    for (size_t i = 0; i < p_interp_vec.size(); i++)
     {
 
       struct InterpResult interp_pose = InterpolatePose(p_interp_vec[i], teach_path_p, teach_path);
@@ -522,7 +521,7 @@ struct PoseResultHomotopy GenerateHomotopyReference(std::shared_ptr<CBITPath> gl
 struct InterpResult InterpolatePose(double p_val, std::vector<double> cbit_p, std::vector<Pose> cbit_path)
 {
   // Find the lower bound of the p values
-  for (int i = 0; i < cbit_p.size(); i++)
+  for (size_t i = 0; i < cbit_p.size(); i++)
   {
     if (cbit_p[i] < p_val)
     {
@@ -606,8 +605,7 @@ Eigen::Matrix<double, 2, 1> SaturateVel(Eigen::Matrix<double, 2, 1> applied_vel,
     Eigen::Matrix<double, 2, 1> saturated_vel;
 
 
-    if (abs(applied_vel(0)) >= v_lim)
-    {
+    if (abs(applied_vel(0)) >= v_lim) {
       if (applied_vel(0) > 0.0)
       {
         command_lin_x = v_lim;
@@ -615,11 +613,10 @@ Eigen::Matrix<double, 2, 1> SaturateVel(Eigen::Matrix<double, 2, 1> applied_vel,
       else if (applied_vel(0)  < 0.0)
       {
         command_lin_x = -1.0* v_lim;
+      } else {
+        command_lin_x = 0;
       }
-    }
-
-    else
-    {
+    } else {
       command_lin_x = applied_vel(0) ;
     }
 
@@ -632,11 +629,10 @@ Eigen::Matrix<double, 2, 1> SaturateVel(Eigen::Matrix<double, 2, 1> applied_vel,
       else if (applied_vel(1)  < 0.0)
       {
         command_ang_z = -1.0 * w_lim;
+      } else {
+        command_ang_z = 0;
       }
-    }
-
-    else
-    {
+    } else {
       command_ang_z = applied_vel(1) ;
     }
 

--- a/main/src/vtr_path_planning/src/mpc/speed_scheduler.cpp
+++ b/main/src/vtr_path_planning/src/mpc/speed_scheduler.cpp
@@ -22,7 +22,7 @@
 #include <iostream>
 
 
-double ScheduleSpeed(const std::vector<double>& disc_path_curvature_xy, const std::vector<double>& disc_path_curvature_xz_yz, double VF, int curr_sid, double planar_curv_weight, double profile_curv_weight, double eop_weight, double horizon_step_size, double min_vel)
+double ScheduleSpeed(const std::vector<double>& disc_path_curvature_xy, const std::vector<double>& disc_path_curvature_xz_yz, double VF, unsigned curr_sid, double planar_curv_weight, double profile_curv_weight, double eop_weight, double horizon_step_size, double min_vel)
 {
 
     // Experimental Speed Scheduler:
@@ -33,7 +33,7 @@ double ScheduleSpeed(const std::vector<double>& disc_path_curvature_xy, const st
 
     // Pseudocode:
     // - Estimate the current p value of the vehicle (doesnt need to be super precise so here we can imply opt to use the sid value)
-    // - Avergage the radius of curvature in the upcoming segments of the path
+    // - Average the radius of curvature in the upcoming segments of the path
 
     // Basic implementation - weights hardcoded for now
     CLOG(INFO, "mpc.speed_scheduler") << "TRYING TO SCHEDULE SPEED:";
@@ -44,8 +44,8 @@ double ScheduleSpeed(const std::vector<double>& disc_path_curvature_xy, const st
     double avg_curvature_xy = 0.0;
     double avg_curvature_xz_yz = 0.0;
     double end_of_path = 0.0;
-    int horizon_steps = 5.0 / horizon_step_size; // Set lookahead horizon to 5m (default params tuned for this value)
-    for (int i = curr_sid; i < curr_sid + horizon_steps; i++) 
+    unsigned horizon_steps = 5.0 / horizon_step_size; // Set lookahead horizon to 5m (default params tuned for this value)
+    for (size_t i = curr_sid; i < curr_sid + horizon_steps; i++) 
     {
       // Handle end of path case
       if (i == (disc_path_curvature_xy.size()-1))
@@ -64,9 +64,9 @@ double ScheduleSpeed(const std::vector<double>& disc_path_curvature_xy, const st
 
     // handle forward/referse case and calculate a candidate VF speed for each of our scheduler modules (XY curvature, XZ curvature, End of Path etc)
 
-    VF_EOP = std::max(0.5, VF / (1 + (end_of_path * end_of_path * eop_weight)));
-    VF_XY = std::max(0.5, VF / (1 + (avg_curvature_xy * avg_curvature_xy * planar_curv_weight)));
-    VF_XZ_YZ = std::max(0.5, VF / (1 + (avg_curvature_xz_yz * avg_curvature_xz_yz * profile_curv_weight)));
+    VF_EOP = std::max(min_vel, VF / (1 + (end_of_path * end_of_path * eop_weight)));
+    VF_XY = std::max(min_vel, VF / (1 + (avg_curvature_xy * avg_curvature_xy * planar_curv_weight)));
+    VF_XZ_YZ = std::max(min_vel, VF / (1 + (avg_curvature_xz_yz * avg_curvature_xz_yz * profile_curv_weight)));
     
     // Take the minimum of all candidate (positive) scheduled speeds (Lowest allowed scheduled velocity is 0.5m/s, should be left this way)
     VF = std::min({VF_EOP, VF_XY, VF_XZ_YZ});


### PR DESCRIPTION
Bug Fixes:
Hopefully, solve the CBIT crash on spline interpolation when the repeat path is less than five vertices long. (Close #201)
Use min speed parameter in the speed scheduler. Was using hard-coded 0.5 m.s

Warnings Reductions:
Change many `int` to `size_t` in for loops. 
Remove some unused parameters
Start migrating namespaces to match conventions. 