### PR TITLE
Resolve Error when the Same Vertex is Added Consecutively.

### DIFF
--- a/main/src/vtr_path_planning/src/cbit/cbit.cpp
+++ b/main/src/vtr_path_planning/src/cbit/cbit.cpp
@@ -555,7 +555,7 @@ auto CBIT::computeCommand(RobotState& robot_state) -> Command {
       mpc_poses = MPCResult.mpc_poses;
       CLOG(INFO, "cbit.control") << "Successfully solved MPC problem";
     }
-    catch(...)
+    catch(steam::unsuccessful_step &e)
     {
       CLOG(WARNING, "cbit.control") << "STEAM Optimization Failed; Commanding to Stop the Vehicle";
       applied_vel(0) = 0.0;

--- a/main/src/vtr_route_planning/src/bfs_planner.cpp
+++ b/main/src/vtr_route_planning/src/bfs_planner.cpp
@@ -39,8 +39,10 @@ auto BFSPlanner::path(const VertexId &from, const VertexId::List &to,
   auto to_iter = std::next(from_iter);
   for (; to_iter != to.end(); ++from_iter, ++to_iter) {
     const auto segment = path(priv_graph, *from_iter, *to_iter);
-    rval.insert(rval.end(), std::next(segment.begin()), segment.end());
-    idx.push_back(rval.empty() ? 0 : (rval.size() - 1));
+    if (segment.size() > 0){
+      rval.insert(rval.end(), std::next(segment.begin()), segment.end());
+      idx.push_back(rval.empty() ? 0 : (rval.size() - 1));
+    }
   }
 
   return rval;


### PR DESCRIPTION
Closes #215 

Also improve the debug-ability of cbit by crashing if verbose is on and NAN values are generated by STEAM.

Switch to DoglegSolver instead of Vanilla Gauss-Newton.