### PR TITLE
Improve End of Path Behaviour

### DIFF
--- a/config/ouster_warthog_default.yaml
+++ b/config/ouster_warthog_default.yaml
@@ -11,6 +11,7 @@
         # tactic
       #- tactic
       - tactic.pipeline
+      - tactic.eop
       #- tactic.module
       #- tactic.module.live_mem_manager
       #- tactic.module.graph_mem_manager
@@ -21,6 +22,7 @@
       #- path_planning.cbit_planner
       - mpc.cbit
       - mpc_debug
+      - cbit.control
       #- obstacle detection.cbit
       #- grizzly_controller_tests.cbit
       #- ouster
@@ -66,7 +68,7 @@
       task_queue_num_threads: 1
       task_queue_size: -1
 
-      route_completion_translation_threshold: 0.5
+      route_completion_translation_threshold: 0.1
 
       chain:
         min_cusp_distance: 1.5
@@ -355,7 +357,7 @@
         vehicle_model: "unicycle"
 
         # Cost Function Covariance Matrices
-        pose_error_cov: [10.0, 10.0, 100.0, 100.0, 100.0, 20.0]
+        pose_error_cov: [10.0, 10.0, 100.0, 100.0, 100.0, 5.0]
         vel_error_cov: [20.0, 30.0]
         acc_error_cov: [20.0, 20.0]
         kin_error_cov: [0.01, 0.01, 0.01, 0.01, 0.01, 0.01]

--- a/main/src/vtr_path_planning/src/cbit/cbit.cpp
+++ b/main/src/vtr_path_planning/src/cbit/cbit.cpp
@@ -315,11 +315,6 @@ auto CBIT::computeCommand(RobotState& robot_state) -> Command {
   // retrieve the transorm info from the localization chain for the current robot state
   const auto chain_info = getChainInfo(robot_state);
   auto [stamp, w_p_r_in_r, T_p_r, T_w_p, T_w_v_odo, T_r_v_odo, curr_sid] = chain_info;
-  if (curr_sid == (chain.size()-2))
-  {
-    CLOG(INFO, "cbit.control") << "Reaching End of Path, Disabling MPC";
-    return Command();
-  }
 
 
   // Handling Dynamic Corridor Widths:
@@ -358,7 +353,7 @@ auto CBIT::computeCommand(RobotState& robot_state) -> Command {
     costmap_ptr->obs_map = obs_map;
     // Store the transform T_c_w (from costmap to world)
     costmap_ptr->T_c_w = T_start_vertex.inverse(); // note that T_start_vertex is T_w_c if we want to bring keypoints to the world frame
-    // Store the grid resoltuion
+    // Store the grid resolution
     CLOG(DEBUG, "cbit.obstacle_filtering") << "The costmap to world transform is: " << T_start_vertex.inverse();
 
     // Storing sequences of costmaps for temporal filtering purposes

--- a/main/src/vtr_tactic/src/tactic.cpp
+++ b/main/src/vtr_tactic/src/tactic.cpp
@@ -166,8 +166,9 @@ bool Tactic::passedSeqId(const uint64_t& sid) const {
 
 bool Tactic::routeCompleted() const {
   auto lock = chain_->guard();
-  const auto translation = chain_->T_leaf_trunk().r_ab_inb().norm();
+  const auto translation = (chain_->T_leaf_trunk()*chain_->T_trunk_target(chain_->sequence().size() - 1)).r_ba_ina().norm();
 
+  CLOG(DEBUG, "tactic.eop") << "Translation: " << translation;
   if (chain_->trunkSequenceId() < (chain_->sequence().size() - 2)) {
     return false;
   }


### PR DESCRIPTION
Remove duplicated behaviour from cbit to determine if the route is complete.

Improve distance check to use actual waypoint target.

Closes #217 