### PR TITLE
Gui Improvements

### DIFF
--- a/config/ouster_jackal_default.yaml
+++ b/config/ouster_jackal_default.yaml
@@ -55,6 +55,7 @@
       origin_lng: -79.4661
       origin_theta: 1.3
       scale: 1.0
+      gps_topic: "/novatel/fix"
     tactic:
       enable_parallelization: true
       preprocessing_skippable: false

--- a/main/src/vtr_gui/vtr_gui/vtr-gui/src/components/goal/GoalForm.js
+++ b/main/src/vtr_gui/vtr_gui/vtr-gui/src/components/goal/GoalForm.js
@@ -43,7 +43,7 @@ class GoalForm extends React.Component {
   }
 
   render() {
-    const { waypointsMap, goalType, goalWaypoints, setNewGoalWaypoints } = this.props;
+    const { goalType, goalWaypoints, setNewGoalWaypoints } = this.props;
     const { goal_form_open, goal_waypoints_str, goal_waypoints_invalid, pause_after, pause_before } = this.state;
     return (
       <>

--- a/main/src/vtr_gui/vtr_gui/vtr-gui/src/components/graph/GraphMap.js
+++ b/main/src/vtr_gui/vtr_gui/vtr-gui/src/components/graph/GraphMap.js
@@ -146,7 +146,7 @@ class GraphMap extends React.Component {
       // map center
       map_center: {lat: 43.78220, lng: -79.4661},
       /// whether the path selection will be the whole path (for annotation)
-      annotateFull: false,
+      annotate_full: false,
     };
     this.fetchMapCenter()
     /// leaflet map
@@ -331,7 +331,6 @@ class GraphMap extends React.Component {
       [43.660511, -79.397019], // Bottom-left coordinates of the image
       [43.661091, -79.395995], // Top-right coordinates of the image
     ];
-    // const [annotateFull, setAnnotateFull] = useState(false);
     return (
       <>
         {/* Leaflet map container with initial center set to UTIAS (only for initialization) */}
@@ -384,8 +383,8 @@ class GraphMap extends React.Component {
         >
           <FormControlLabel control={
             <Switch
-              checked={this.state.annotateFull}
-              onChange={() => this.setState({annotateFull: !this.state.annotateFull})}
+              checked={this.state.annotate_full}
+              onChange={() => this.setState({annotate_full: !this.state.annotate_full})}
               inputProps={{ 'aria-label': 'controlled' }}
             />
           } label={
@@ -976,7 +975,7 @@ class GraphMap extends React.Component {
     let interm_pos = { s: null, c: null, e: null };
 
     let getSelectedPath = () => {
-      if (!this.state.annotateFull) {
+      if (!this.state.annotate_full) {
         let paths = this.breadthFirstSearch(selector.vertex.c.id, [selector.vertex.s.id, selector.vertex.e.id]);
         paths[0].reverse();
         return paths[0].concat(paths[1].slice(1));
@@ -1534,7 +1533,6 @@ class GraphMap extends React.Component {
   }
 
   metres2pix(metres) {
-    // Compute conversion factor ( better way of doing this)
     let origin = L.latLng(this.id2vertex.get(this.root_vid));
     let origin_plus_metre = this.map.latLngToLayerPoint(L.latLng(origin.lat - 1, origin.lng));
     let metre_standard = origin_plus_metre.subtract(this.map.latLngToLayerPoint(origin));

--- a/main/src/vtr_gui/vtr_gui/vtr-gui/src/components/graph/GraphMap.js
+++ b/main/src/vtr_gui/vtr_gui/vtr-gui/src/components/graph/GraphMap.js
@@ -982,11 +982,10 @@ class GraphMap extends React.Component {
         return paths[0].concat(paths[1].slice(1));
       }
       else {
-        let paths = Array.from(this.id2vertex.keys());
-        paths.sort(function(a, b) {
-          return a - b;
-        });
-        return paths;
+        let end_id = Math.max(...Array.from(this.id2vertex.keys()));
+        let paths = this.breadthFirstSearch(selector.vertex.c.id, [0, end_id]);
+        paths[0].reverse();
+        return paths[0].concat(paths[1].slice(1));
       }
     };
 

--- a/main/src/vtr_gui/vtr_gui/vtr-gui/src/components/graph/GraphMap.js
+++ b/main/src/vtr_gui/vtr_gui/vtr-gui/src/components/graph/GraphMap.js
@@ -550,17 +550,17 @@ class GraphMap extends React.Component {
       .catch((error) => {
         console.error(error);
       });
-  }
-
-  graphStateCallback(graph_state) {
-    console.info("Received graph state: ", graph_state);
-    this.loadGraphState(graph_state);
-  }
-
-  /** @brief Helper function to convert a pose graph route to a leaflet polyline, and add it to map */
-  route2Polyline(route) {
-    // fixed_routes format: [{type: 0, ids: [id, ...]}, ...]
-    let color = ROUTE_TYPE_COLOR[route.type % ROUTE_TYPE_COLOR.length];
+    }
+    
+    graphStateCallback(graph_state) {
+      console.info("Received graph state: ", graph_state);
+      this.loadGraphState(graph_state);
+    }
+    
+    /** @brief Helper function to convert a pose graph route to a leaflet polyline, and add it to map */
+    route2Polyline(route) {
+      // fixed_routes format: [{type: 0, ids: [id, ...]}, ...]
+      let color = ROUTE_TYPE_COLOR[route.type % ROUTE_TYPE_COLOR.length];
     let width = route.type + 2
     let latlngs = route.ids.map((id) => {
       let v = this.id2vertex.get(id);
@@ -594,7 +594,7 @@ class GraphMap extends React.Component {
         wps_map.set(v.id, v.name);
       }
     });
-    this.setState({waypoints_map: wps_map, display_waypoints_map: wps_map}); 
+    this.setState({waypoints_map: wps_map, display_waypoints_map: wps_map});
 
     this.kdtree = new kdTree(graph.vertices, (a, b) => b.distanceTo(a), ["lat", "lng"]);
     // fixed routes

--- a/main/src/vtr_gui/vtr_gui/vtr-gui/src/components/graph/GraphMap.js
+++ b/main/src/vtr_gui/vtr_gui/vtr-gui/src/components/graph/GraphMap.js
@@ -48,10 +48,11 @@ import DeleteIcon from "@mui/icons-material/Delete";
 
 /// pose graph constants
 const ROUTE_TYPE_COLOR = ["#ff0000", "#fd4a18", "#ffa500", "#fecd29", "#ffff00", "#6aaf1e", "#008000", "#000000"];
-const ROUTE_TYPE_WIDTH = [0.2, 0.5, 1.0, 1.5, 2.0, 2.5, 10.0, 0.05];
+const ROUTE_TYPE_WIDTH = [0.4, 1.0, 2.0, 3.0, 4.0, 5.0, 20.0, 0.05];
 const ROUTE_TYPE_OPACITY = [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.9];
+const ANNOTATE_LINE_COLOR = "#000000";
+const ANNOTATE_LINE_WIDTH = 0.5;
 const GRAPH_OPACITY = 0.9;
-const GRAPH_WEIGHT = 7;
 
 /// robot constants
 const ROBOT_OPACITY = 0.8;
@@ -1157,11 +1158,11 @@ class GraphMap extends React.Component {
         });
         if (this.annotate_polyline === null) {
           this.annotate_polyline = L.polyline(latlngs, {
-            color: "#000000",
+            color: ANNOTATE_LINE_COLOR,
             opacity: GRAPH_OPACITY,
-            weight: GRAPH_WEIGHT,
+            weight: this.metres2pix(ANNOTATE_LINE_WIDTH),
             pane: "graph",
-            lineCap: "butt"
+            lineCap: "butt",
           });
           this.annotate_polyline.addTo(this.map);
         } else {
@@ -1172,13 +1173,15 @@ class GraphMap extends React.Component {
     this.createSelector(this.annotate_route_selector, selectPathCallback);
 
     this.annotateRouteZoomEnd = () => {
+
       let type = this.state.annotate_route_type;
       this.setState({ annotate_route_type: type }, () =>
         this.annotate_polyline.setStyle({ 
-          color: ROUTE_TYPE_COLOR[type % ROUTE_TYPE_COLOR.length],
-          weight: this.metres2pix(ROUTE_TYPE_WIDTH[type % ROUTE_TYPE_COLOR.length]),
-          opacity: ROUTE_TYPE_OPACITY[type % ROUTE_TYPE_COLOR.length],
-          lineCap: "butt"
+          color: ANNOTATE_LINE_COLOR,
+          opacity: GRAPH_OPACITY,
+          weight: this.metres2pix(ANNOTATE_LINE_WIDTH),
+          pane: "graph",
+          lineCap: "butt",
         })
       );
     };
@@ -1204,10 +1207,11 @@ class GraphMap extends React.Component {
     if (this.annotate_polyline === null) return;
     this.setState({ annotate_route_type: type }, () =>
       this.annotate_polyline.setStyle({ 
-        color: ROUTE_TYPE_COLOR[type % ROUTE_TYPE_COLOR.length],
-        weight: this.metres2pix(ROUTE_TYPE_WIDTH[type % ROUTE_TYPE_COLOR.length]),
-        opacity: ROUTE_TYPE_OPACITY[type % ROUTE_TYPE_COLOR.length],
-        lineCap: "butt"
+        color: ANNOTATE_LINE_COLOR,
+        opacity: GRAPH_OPACITY,
+        weight: this.metres2pix(ANNOTATE_LINE_WIDTH),
+        pane: "graph",
+        lineCap: "butt",
       })
     );
   }

--- a/main/src/vtr_gui/vtr_gui/vtr-gui/src/components/graph/GraphMap.js
+++ b/main/src/vtr_gui/vtr_gui/vtr-gui/src/components/graph/GraphMap.js
@@ -372,15 +372,15 @@ class GraphMap extends React.Component {
           moveRobotVertex={move_robot_vertex}
         />
         <Box
-        sx={{
-          position: "absolute",
-          bottom: 0,
-          left: "77%",
-          transform: "translate(-50%, -50%)",
-          zIndex: 1000,
-          display: "flex",
-          flexDirection: "row",
-        }}
+          sx={{
+            position: "absolute",
+            bottom: 0,
+            left: "77%",
+            transform: "translate(-50%, -50%)",
+            zIndex: 1000,
+            display: "flex",
+            flexDirection: "row",
+          }}
         >
           <FormControlLabel control={
             <Switch
@@ -519,7 +519,6 @@ class GraphMap extends React.Component {
       if (this.state.new_goal_type === "repeat") {
         this.setState({ new_goal_waypoints: [...this.state.new_goal_waypoints, best.target.id] });
       }
-      console.log(this.state.waypoints_map);
     }
   }
 
@@ -536,31 +535,31 @@ class GraphMap extends React.Component {
   fetchGraphState(center = false) {
     console.info("Fetching the current pose graph state (full).");
     fetchWithTimeout("/vtr/graph")
-      .then((response) => {
-        if (response.status !== 200) throw new Error("Failed to fetch pose graph state: " + response.status);
-        response.json().then((data) => {
-          console.info("Received the pose graph state (full): ", data);
-          this.loadGraphState(data, center);
-          // fetch robot and following route after graph has been set
-          this.fetchRobotState();
-          this.fetchFollowingRoute();
-          this.fetchServerState();
-        });
-      })
-      .catch((error) => {
-        console.error(error);
+    .then((response) => {
+      if (response.status !== 200) throw new Error("Failed to fetch pose graph state: " + response.status);
+      response.json().then((data) => {
+        console.info("Received the pose graph state (full): ", data);
+        this.loadGraphState(data, center);
+        // fetch robot and following route after graph has been set
+        this.fetchRobotState();
+        this.fetchFollowingRoute();
+        this.fetchServerState();
       });
-    }
+    })
+    .catch((error) => {
+      console.error(error);
+    });
+  }
     
-    graphStateCallback(graph_state) {
-      console.info("Received graph state: ", graph_state);
-      this.loadGraphState(graph_state);
-    }
-    
-    /** @brief Helper function to convert a pose graph route to a leaflet polyline, and add it to map */
-    route2Polyline(route) {
-      // fixed_routes format: [{type: 0, ids: [id, ...]}, ...]
-      let color = ROUTE_TYPE_COLOR[route.type % ROUTE_TYPE_COLOR.length];
+  graphStateCallback(graph_state) {
+    console.info("Received graph state: ", graph_state);
+    this.loadGraphState(graph_state);
+  }
+  
+  /** @brief Helper function to convert a pose graph route to a leaflet polyline, and add it to map */
+  route2Polyline(route) {
+    // fixed_routes format: [{type: 0, ids: [id, ...]}, ...]
+    let color = ROUTE_TYPE_COLOR[route.type % ROUTE_TYPE_COLOR.length];
     let width = route.type + 2
     let latlngs = route.ids.map((id) => {
       let v = this.id2vertex.get(id);
@@ -660,7 +659,6 @@ class GraphMap extends React.Component {
         this.robot_marker.marker.remove();
       }
     } else {
-      console.log(robot.lng, robot.lat);
       this.robot_marker.marker.setLatLng({ lng: robot.lng, lat: robot.lat });
       this.robot_marker.marker.setOpacity(robot.localized ? ROBOT_OPACITY : ROBOT_UNLOCALIZED_OPACITY);
       this.robot_marker.marker.setRotationAngle(-(robot.theta / Math.PI) * 180);
@@ -950,7 +948,6 @@ class GraphMap extends React.Component {
           current = parents.get(current);
         }
       }
-      
       paths.push(path);
     });
 
@@ -1052,7 +1049,6 @@ class GraphMap extends React.Component {
     let closest_vertices = this.kdtree.nearest(center_pos, 1);
     selector.vertex.c = closest_vertices ? closest_vertices[0][0] : center_pos;
     selector.vertex.c = this.id2vertex.get(0);
-    console.log("Selector centre", selector.vertex.c, this.id2vertex.get(0));
     selector.marker.c = L.marker(selector.vertex.c, {
       draggable: true,
       icon: SELECTOR_CENTER_ICON,
@@ -1282,13 +1278,13 @@ class GraphMap extends React.Component {
       console.warn(move_graph_change);
       this.setState({ move_graph_change: move_graph_change });
     };
-    
+
     let updateGraphPane = () => {
       let style = this.map.getPane("graph").style;
       /// transform origin
       let origin_p = this.map.latLngToLayerPoint(origin);
       style.transformOrigin = `${origin_p.x}px ${origin_p.y}px`;
-      
+
       /// transform
       let trans_loc_p = this.map.latLngToLayerPoint(trans_loc);
       let rot_loc_p = this.map.latLngToLayerPoint(rot_loc);

--- a/main/src/vtr_gui/vtr_gui/vtr-gui/src/components/setup/StartMenu.js
+++ b/main/src/vtr_gui/vtr_gui/vtr-gui/src/components/setup/StartMenu.js
@@ -92,6 +92,7 @@ class StartMenu extends React.Component {constructor(props) {
                 width: "90%",
                 margin: "5% 10% 0% 0%",
               }}
+              alt="ASRL"
             />
             <div
               style={{

--- a/main/src/vtr_gui/vtr_gui/vtr-gui/src/components/tools/ToolsMenu.js
+++ b/main/src/vtr_gui/vtr_gui/vtr-gui/src/components/tools/ToolsMenu.js
@@ -70,14 +70,6 @@ class ToolsMenu extends React.Component {
           waypointsMap={this.props.waypointsMap}
           handleUpdateWaypoint={this.props.handleUpdateWaypoint}
         />
-        <DeleteWaypoints
-          socket={socket}
-          active={currentTool === "delete_waypoints" ? true : false}
-          onSelect={() => selectTool("delete_waypoints")}
-          onCancel={deselectTool}
-          waypointsMap={this.props.waypointsMap}
-          handleUpdateWaypoint={this.props.handleUpdateWaypoint}
-        />
       </Box>
     );
   }

--- a/main/src/vtr_gui/vtr_gui/vtr-gui/src/components/tools/ToolsMenu.js
+++ b/main/src/vtr_gui/vtr_gui/vtr-gui/src/components/tools/ToolsMenu.js
@@ -83,4 +83,4 @@ class ToolsMenu extends React.Component {
   }
 }
 
-export default ToolsMenu
+export default ToolsMenu;

--- a/main/src/vtr_gui/vtr_gui/vtr-gui/src/components/tools/ToolsMenu.js
+++ b/main/src/vtr_gui/vtr_gui/vtr-gui/src/components/tools/ToolsMenu.js
@@ -17,7 +17,7 @@
 
 import React from "react";
 
-import { Box, Switch } from "@mui/material";
+import { Box } from "@mui/material";
 
 import AnnotateRoute from "./AnnotateRoute";
 import DeleteWaypoints from "./DeleteWaypoints";
@@ -25,26 +25,19 @@ import MoveGraph from "./MoveGraph";
 import MoveRobot from "./MoveRobot";
 
 class ToolsMenu extends React.Component {
-  
-  constructor(props) {
-    super(props);
-    this.isChecked = true;
-    this.handleCheckboxChange = this.handleCheckboxChange.bind(this);
-  }
-  
   render() {
     const { socket, currentTool, selectTool, deselectTool } = this.props;
     return (
       <Box
-      sx={{
-        position: "absolute",
-        bottom: 0,
-        left: "50%",
-        transform: "translate(-50%, -50%)",
-        zIndex: 1000,
-        display: "flex",
-        flexDirection: "row",
-      }}
+        sx={{
+          position: "absolute",
+          bottom: 0,
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          zIndex: 1000,
+          display: "flex",
+          flexDirection: "row",
+        }}
       >
         <MoveRobot
           socket={socket}
@@ -52,14 +45,14 @@ class ToolsMenu extends React.Component {
           onSelect={() => selectTool("move_robot")}
           onCancel={deselectTool}
           moveRobotVertex={this.props.moveRobotVertex}
-          />
+        />
         <MoveGraph
           socket={socket}
           active={currentTool === "move_graph" ? true : false}
           onSelect={() => selectTool("move_graph")}
           onCancel={deselectTool}
           moveGraphChange={this.props.moveGraphChange}
-          />
+        />
         <AnnotateRoute
           socket={socket}
           active={currentTool === "annotate_route" ? true : false}
@@ -68,7 +61,7 @@ class ToolsMenu extends React.Component {
           onSliderChange={this.props.onSliderChange}
           annotateRouteType={this.props.annotateRouteType}
           annotateRouteIds={this.props.annotateRouteIds}
-          />
+        />
         <DeleteWaypoints
           socket={socket}
           active={currentTool === "delete_waypoints" ? true : false}
@@ -76,7 +69,7 @@ class ToolsMenu extends React.Component {
           onCancel={deselectTool}
           waypointsMap={this.props.waypointsMap}
           handleUpdateWaypoint={this.props.handleUpdateWaypoint}
-          />
+        />
         <DeleteWaypoints
           socket={socket}
           active={currentTool === "delete_waypoints" ? true : false}
@@ -84,19 +77,9 @@ class ToolsMenu extends React.Component {
           onCancel={deselectTool}
           waypointsMap={this.props.waypointsMap}
           handleUpdateWaypoint={this.props.handleUpdateWaypoint}
-          />
+        />
       </Box>
     );
-  }
-  
-  handleCheckboxChange(event) {
-    this.isChecked = event.target.checked;
-    if (event.target.checked) {
-      console.log("Checked");
-    }
-    else {
-      console.log("Unchecked");
-    }
   }
 }
 

--- a/main/src/vtr_gui/vtr_gui/vtr-gui/src/components/tools/ToolsMenu.js
+++ b/main/src/vtr_gui/vtr_gui/vtr-gui/src/components/tools/ToolsMenu.js
@@ -17,7 +17,7 @@
 
 import React from "react";
 
-import { Box } from "@mui/material";
+import { Box, Switch } from "@mui/material";
 
 import AnnotateRoute from "./AnnotateRoute";
 import DeleteWaypoints from "./DeleteWaypoints";
@@ -25,19 +25,26 @@ import MoveGraph from "./MoveGraph";
 import MoveRobot from "./MoveRobot";
 
 class ToolsMenu extends React.Component {
+  
+  constructor(props) {
+    super(props);
+    this.isChecked = true;
+    this.handleCheckboxChange = this.handleCheckboxChange.bind(this);
+  }
+  
   render() {
     const { socket, currentTool, selectTool, deselectTool } = this.props;
     return (
       <Box
-        sx={{
-          position: "absolute",
-          bottom: 0,
-          left: "50%",
-          transform: "translate(-50%, -50%)",
-          zIndex: 1000,
-          display: "flex",
-          flexDirection: "row",
-        }}
+      sx={{
+        position: "absolute",
+        bottom: 0,
+        left: "50%",
+        transform: "translate(-50%, -50%)",
+        zIndex: 1000,
+        display: "flex",
+        flexDirection: "row",
+      }}
       >
         <MoveRobot
           socket={socket}
@@ -45,14 +52,14 @@ class ToolsMenu extends React.Component {
           onSelect={() => selectTool("move_robot")}
           onCancel={deselectTool}
           moveRobotVertex={this.props.moveRobotVertex}
-        />
+          />
         <MoveGraph
           socket={socket}
           active={currentTool === "move_graph" ? true : false}
           onSelect={() => selectTool("move_graph")}
           onCancel={deselectTool}
           moveGraphChange={this.props.moveGraphChange}
-        />
+          />
         <AnnotateRoute
           socket={socket}
           active={currentTool === "annotate_route" ? true : false}
@@ -61,7 +68,7 @@ class ToolsMenu extends React.Component {
           onSliderChange={this.props.onSliderChange}
           annotateRouteType={this.props.annotateRouteType}
           annotateRouteIds={this.props.annotateRouteIds}
-        />
+          />
         <DeleteWaypoints
           socket={socket}
           active={currentTool === "delete_waypoints" ? true : false}
@@ -69,10 +76,28 @@ class ToolsMenu extends React.Component {
           onCancel={deselectTool}
           waypointsMap={this.props.waypointsMap}
           handleUpdateWaypoint={this.props.handleUpdateWaypoint}
-        />
+          />
+        <DeleteWaypoints
+          socket={socket}
+          active={currentTool === "delete_waypoints" ? true : false}
+          onSelect={() => selectTool("delete_waypoints")}
+          onCancel={deselectTool}
+          waypointsMap={this.props.waypointsMap}
+          handleUpdateWaypoint={this.props.handleUpdateWaypoint}
+          />
       </Box>
     );
   }
+  
+  handleCheckboxChange(event) {
+    this.isChecked = event.target.checked;
+    if (event.target.checked) {
+      console.log("Checked");
+    }
+    else {
+      console.log("Unchecked");
+    }
+  }
 }
 
-export default ToolsMenu;
+export default ToolsMenu

--- a/main/src/vtr_navigation/include/vtr_navigation/graph_map_server.hpp
+++ b/main/src/vtr_navigation/include/vtr_navigation/graph_map_server.hpp
@@ -31,6 +31,7 @@
 
 #include "vtr_navigation_msgs/msg/annotate_route.hpp"
 #include "vtr_navigation_msgs/msg/update_waypoint.hpp"
+#include "vtr_navigation_msgs/msg/mission_command.hpp"
 #include "vtr_navigation_msgs/msg/graph_route.hpp"
 #include "vtr_navigation_msgs/msg/graph_state.hpp"
 #include "vtr_navigation_msgs/msg/graph_update.hpp"
@@ -69,6 +70,8 @@ class GraphMapServer : public tactic::Graph::Callback,
   using MoveGraphMsg = vtr_navigation_msgs::msg::MoveGraph;
   using AnnotateRouteMsg = vtr_navigation_msgs::msg::AnnotateRoute;
   using UpdateWaypointMsg = vtr_navigation_msgs::msg::UpdateWaypoint;
+  using MissionCommandMsg = vtr_navigation_msgs::msg::MissionCommand;
+  using GoalHandle = vtr_navigation_msgs::msg::GoalHandle;
 
   using VertexPtr = tactic::Graph::VertexPtr;
   using EdgePtr = tactic::Graph::EdgePtr;
@@ -113,6 +116,7 @@ class GraphMapServer : public tactic::Graph::Callback,
   void annotateRouteCallback(const AnnotateRouteMsg::ConstSharedPtr msg);
   void poseCallback(const NavSatFix::ConstSharedPtr msg);
   void updateWaypointCallback(const UpdateWaypointMsg::ConstSharedPtr msg);
+  void updateMissionCallback(const MissionCommandMsg::ConstSharedPtr msg);
 
  private:
   /// these functions are called with graph mutex locked
@@ -160,6 +164,8 @@ class GraphMapServer : public tactic::Graph::Callback,
   /** \brief Vertices and routes */
   GraphState graph_state_;
 
+  uint goal_;
+
   /**
    * \brief Cached robot persistent & target localization used after graph
    * relaxation and calibration
@@ -200,6 +206,7 @@ class GraphMapServer : public tactic::Graph::Callback,
   rclcpp::Subscription<MoveGraphMsg>::SharedPtr move_graph_sub_;
   rclcpp::Subscription<AnnotateRouteMsg>::SharedPtr annotate_route_sub_;
   rclcpp::Subscription<UpdateWaypointMsg>::SharedPtr update_waypoint_sub_;
+  rclcpp::Subscription<MissionCommandMsg>::SharedPtr mission_command_sub_;
 
   rclcpp::Subscription<NavSatFix>::SharedPtr pose_pub_;
 

--- a/main/src/vtr_navigation/include/vtr_navigation/graph_map_server.hpp
+++ b/main/src/vtr_navigation/include/vtr_navigation/graph_map_server.hpp
@@ -20,7 +20,6 @@
 
 #include <utility>
 #include <proj.h>
-#include <boost/circular_buffer.hpp>
 #include <math.h>
 #include <cmath>
 
@@ -206,7 +205,7 @@ class GraphMapServer : public tactic::Graph::Callback,
 
   const float dist_thres_ = 0.1;
   bool initial_pose_set_ = false;
-  boost::circular_buffer<std::pair<int, int>> gps_coords_ {2};
+  std::deque<std::pair<int, int>> gps_coords_ {2};
 };
 
 class RvizGraphMapServer : public GraphMapServer,

--- a/main/src/vtr_navigation/include/vtr_navigation/graph_map_server.hpp
+++ b/main/src/vtr_navigation/include/vtr_navigation/graph_map_server.hpp
@@ -18,7 +18,11 @@
  */
 #pragma once
 
+#include <utility>
 #include <proj.h>
+#include <boost/circular_buffer.hpp>
+#include <math.h>
+#include <cmath>
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -139,6 +143,10 @@ class GraphMapServer : public tactic::Graph::Callback,
 
   void updateRobotProjection();
 
+  float haversineDist(float lat1, float lat2, float lon1, float lon2);
+  float deltaLongToMetres(float lat1, float lat2, float lon1, float lon2);
+  float deltaLatToMetres(float lat1, float lat2);
+
  private:
   /** \brief Graph that generates the callbacks */
   GraphWeakPtr graph_;
@@ -197,9 +205,9 @@ class GraphMapServer : public tactic::Graph::Callback,
 
   rclcpp::Subscription<NavSatFix>::SharedPtr pose_pub_;
 
-  unsigned int set_starting_pose_ = 0;
-  float prev_lat_;
-  float prev_lng_;
+  const float dist_thres_ = 0.1;
+  bool initial_pose_set_ = false;
+  boost::circular_buffer<std::pair<int, int>> gps_coords_ {2};
 };
 
 class RvizGraphMapServer : public GraphMapServer,

--- a/main/src/vtr_navigation/include/vtr_navigation/graph_map_server.hpp
+++ b/main/src/vtr_navigation/include/vtr_navigation/graph_map_server.hpp
@@ -190,7 +190,6 @@ class GraphMapServer : public tactic::Graph::Callback,
   rclcpp::Publisher<RobotState>::SharedPtr robot_state_pub_;
   rclcpp::Service<RobotStateSrv>::SharedPtr robot_state_srv_;
 
-
   /** \brief Service to request the initialized map info */
   rclcpp::Service<MapInfoSrv>::SharedPtr map_info_srv_;
 

--- a/main/src/vtr_navigation/include/vtr_navigation/graph_map_server.hpp
+++ b/main/src/vtr_navigation/include/vtr_navigation/graph_map_server.hpp
@@ -38,6 +38,7 @@
 #include "vtr_navigation_msgs/srv/robot_state.hpp"
 #include "vtr_pose_graph_msgs/msg/map_info.hpp"
 #include "vtr_pose_graph_msgs/srv/map_info.hpp"
+#include "sensor_msgs/msg/nav_sat_fix.hpp"
 
 namespace vtr {
 namespace navigation {
@@ -76,6 +77,8 @@ class GraphMapServer : public tactic::Graph::Callback,
   using GraphWeakPtr = tactic::Graph::WeakPtr;
   using GraphBasePtr = tactic::GraphBase::Ptr;
 
+  using NavSatFix = sensor_msgs::msg::NavSatFix;
+
   using VertexId2TransformMap = std::unordered_map<VertexId, Transform>;
   using VertexId2IdxMap = std::unordered_map<VertexId, size_t>;
   using ProjectVertex =
@@ -105,6 +108,7 @@ class GraphMapServer : public tactic::Graph::Callback,
       std::shared_ptr<MapInfoSrv::Response> response) const;
   void moveGraphCallback(const MoveGraphMsg::ConstSharedPtr msg);
   void annotateRouteCallback(const AnnotateRouteMsg::ConstSharedPtr msg);
+  void poseCallback(const NavSatFix::ConstSharedPtr msg);
   void updateWaypointCallback(const UpdateWaypointMsg::ConstSharedPtr msg);
 
  private:
@@ -178,6 +182,7 @@ class GraphMapServer : public tactic::Graph::Callback,
   rclcpp::Publisher<RobotState>::SharedPtr robot_state_pub_;
   rclcpp::Service<RobotStateSrv>::SharedPtr robot_state_srv_;
 
+
   /** \brief Service to request the initialized map info */
   rclcpp::Service<MapInfoSrv>::SharedPtr map_info_srv_;
 
@@ -189,6 +194,12 @@ class GraphMapServer : public tactic::Graph::Callback,
   rclcpp::Subscription<MoveGraphMsg>::SharedPtr move_graph_sub_;
   rclcpp::Subscription<AnnotateRouteMsg>::SharedPtr annotate_route_sub_;
   rclcpp::Subscription<UpdateWaypointMsg>::SharedPtr update_waypoint_sub_;
+
+  rclcpp::Subscription<NavSatFix>::SharedPtr pose_pub_;
+
+  unsigned int set_starting_pose_ = 0;
+  float prev_lat_;
+  float prev_lng_;
 };
 
 class RvizGraphMapServer : public GraphMapServer,


### PR DESCRIPTION
A set of small improvements to the GUI:
1. The path is now displayed with its actual width (referenced to the underlying map, not the screen). It adjusts dynamically as you zoom such that the path annotation remains true to the map for all zoom levels.
2. The path width is now shown as a translucent band, with a black centre-line along the actual path.
3. A toggle now allows you to select the whole path at once without needing manual selection.
4. If the /novatel/fix topic is present (the topic is configurable), the path is automatically initialized at the location of the first GPS coordinate. The initial heading is approximated using the first few GPS points but this is not fool-proof. Manual rotation may still be required (improvements to follow in a future PR).
5. When the selector is used for annotating or merging, it is now set to point 0 of the path, instead of the point along the path closest to the centre of the map.