### PR TITLE
Updated radar_lidar to new radar pipeline, QOL and clean-up updates for radar conversion and extraction modules

### DIFF
--- a/main/src/vtr_lidar/include/vtr_lidar/modules/odometry/odometry_icp_module.hpp
+++ b/main/src/vtr_lidar/include/vtr_lidar/modules/odometry/odometry_icp_module.hpp
@@ -72,6 +72,10 @@ class OdometryICPModule : public tactic::BaseModule {
 
     /// Success criteria
     float min_matched_ratio = 0.4;
+    float max_trans_vel_diff = 1000.0; // m/s
+    float max_rot_vel_diff = 1000.0; // m/s
+    float max_trans_diff = 1000.0; // m
+    float max_rot_diff = 1000.0; // rad
 
     bool visualize = false;
 

--- a/main/src/vtr_lidar/src/modules/odometry/odometry_icp_module.cpp
+++ b/main/src/vtr_lidar/src/modules/odometry/odometry_icp_module.cpp
@@ -76,6 +76,10 @@ auto OdometryICPModule::Config::fromROS(const rclcpp::Node::SharedPtr &node,
   config->max_iterations = (unsigned int)node->declare_parameter<int>(param_prefix + ".max_iterations", 1);
 
   config->min_matched_ratio = node->declare_parameter<float>(param_prefix + ".min_matched_ratio", config->min_matched_ratio);
+  config->max_trans_vel_diff = node->declare_parameter<float>(param_prefix + ".max_trans_vel_diff", config->max_trans_vel_diff);
+  config->max_rot_vel_diff = node->declare_parameter<float>(param_prefix + ".max_rot_vel_diff", config->max_rot_vel_diff);
+  config->max_trans_diff = node->declare_parameter<float>(param_prefix + ".max_trans_diff", config->max_trans_diff);
+  config->max_rot_diff = node->declare_parameter<float>(param_prefix + ".max_rot_diff", config->max_rot_diff);
 
   config->visualize = node->declare_parameter<bool>(param_prefix + ".visualize", config->visualize);
   // clang-format on
@@ -261,6 +265,7 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
   Eigen::MatrixXd all_tfs = Eigen::MatrixXd::Zero(4, 4);
   bool refinement_stage = false;
   int refinement_step = 0;
+  bool solver_failed = false;
 
   CLOG(DEBUG, "lidar.odometry_icp") << "Start the ICP optimization loop.";
   for (int step = 0;; step++) {
@@ -352,14 +357,15 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
     GaussNewtonSolver::Params params;
     params.verbose = config_->verbose;
     params.max_iterations = (unsigned int)config_->max_iterations;
-    GaussNewtonSolver solver(problem, params);
 
-    try{
+    GaussNewtonSolver solver(problem, params);
+    try {
       solver.optimize();
-    } catch (std::runtime_error& e) {
-      CLOG(WARNING, "lidar.odometry_icp") <<  "Steam failed.\n e.what(): " << e.what();
-      break;
+    } catch(const std::runtime_error& e) {
+      CLOG(WARNING, "lidar.odometry_icp") << "STEAM failed to solve, skipping frame. Error message: " << e.what();
+      solver_failed = true;
     }
+
     Covariance covariance(solver);
     timer[3]->stop();
 
@@ -438,7 +444,8 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
     if ((refinement_stage && step >= max_it - 1) ||
         (refinement_step > config_->averaging_num_steps &&
          mean_dT < config_->trans_diff_thresh &&
-         mean_dR < config_->rot_diff_thresh)) {
+         mean_dR < config_->rot_diff_thresh) ||
+         solver_failed) {
       // result
       if (config_->use_trajectory_estimation) {
         Eigen::Matrix<double, 6, 6> T_r_m_cov = Eigen::Matrix<double, 6, 6>::Identity();
@@ -473,7 +480,41 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
   }
 
   /// Outputs
-  if (matched_points_ratio > config_->min_matched_ratio) {
+  bool estimate_reasonable = true;
+  // Check if change between initial and final velocity is reasonable
+  if (config_->use_trajectory_estimation) {
+    const auto &w_m_r_in_r_prev = trajectory->getVelocityInterpolator(Time(static_cast<int64_t>(timestamp_odo)))->evaluate().matrix();
+    const auto &w_m_r_in_r_new = trajectory->getVelocityInterpolator(Time(static_cast<int64_t>(query_stamp)))->evaluate().matrix();
+    const auto vel_diff = w_m_r_in_r_new - w_m_r_in_r_prev;
+    const auto vel_diff_norm = vel_diff.norm();
+    const auto trans_vel_diff_norm = vel_diff.head<3>().norm();
+    const auto rot_vel_diff_norm = vel_diff.tail<3>().norm();
+
+    const auto T_r_m_prev = trajectory->getPoseInterpolator(timestamp_odo)->value();
+    const auto T_r_m_query = T_r_m_eval->value();
+    const auto diff_T = (T_r_m_query.inverse() * T_r_m_prev).vec();
+    const auto diff_T_trans = diff_T.head<3>().norm();
+    const auto diff_T_rot = diff_T.tail<3>().norm();
+    
+    CLOG(DEBUG, "lidar.odometry_icp") << "Current transformation difference: " << diff_T.transpose();
+    CLOG(DEBUG, "lidar.odometry_icp") << "Current velocity difference: " << vel_diff.transpose();
+
+    if (trans_vel_diff_norm > config_->max_trans_vel_diff || rot_vel_diff_norm > config_->max_rot_vel_diff) {
+      CLOG(WARNING, "lidar.odometry_icp") << "Velocity difference between initial and final is too large: " << vel_diff_norm << ". Translational velocity difference: " << trans_vel_diff_norm << ". Rotational velocity difference: " << rot_vel_diff_norm;
+      estimate_reasonable = false;
+    }
+
+    if (diff_T_trans > config_->max_trans_diff) {
+      CLOG(WARNING, "lidar.odometry_icp") << "Transformation difference between initial and final translation is too large. Transform difference vector: " << diff_T.transpose();
+      estimate_reasonable = false;
+    }
+    if (diff_T_rot > config_->max_rot_diff) {
+      CLOG(WARNING, "lidar.odometry_icp") << "Transformation difference between initial and final rotation is too large. Transform difference vector: " << diff_T.transpose();
+      estimate_reasonable = false;
+    }
+  }
+
+  if (matched_points_ratio > config_->min_matched_ratio && estimate_reasonable && !solver_failed) {
     // undistort the preprocessed pointcloud
     const auto T_s_m = T_m_s_eval->evaluate().matrix().inverse().cast<float>();
     aligned_mat = T_s_m * aligned_mat;
@@ -518,9 +559,11 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
     
     *qdata.odo_success = true;
   } else {
-    CLOG(WARNING, "lidar.odometry_icp")
-        << "Matched points ratio " << matched_points_ratio
-        << " is below the threshold. ICP is considered failed.";
+    if (matched_points_ratio <= config_->min_matched_ratio) {
+      CLOG(WARNING, "lidar.odometry_icp")
+          << "Matched points ratio " << matched_points_ratio
+          << " is below the threshold. ICP is considered failed.";
+    }
     // do not undistort the pointcloud
     auto undistorted_point_cloud = std::make_shared<pcl::PointCloud<PointWithInfo>>(query_points);
     cart2pol(*undistorted_point_cloud);

--- a/main/src/vtr_radar/include/vtr_radar/detector/detector.inl
+++ b/main/src/vtr_radar/include/vtr_radar/detector/detector.inl
@@ -609,15 +609,7 @@ void CASO_CFAR<PointT>::run(const cv::Mat &raw_scan, const float &res,
   if (mincol > cols || mincol < 0) mincol = 0;
   auto maxcol = maxr_ / res - w2 - guard_;
   if (maxcol > cols || maxcol < 0) maxcol = cols;
-  // const int N = maxcol - mincol;  not used
 
-  // // debug
-  // std::cout<< "width:" << width_<<std::endl;
-  // std::cout<< "Guard:" << guard_<<std::endl;
-  // std::cout<< "Theshold" << threshold_<<std::endl;
-  // std::cout<< "minr" << minr_<<std::endl;
-  // std::cout<< "maxr" << maxr_<<std::endl;
-  
   // Convert Navtechs 8-bit dB half steps to watts
   cv::Mat raw_scan_watts_sqrd = raw_scan.clone();
   double conversion_factor = 255.0/20.0*std::log(10.0);

--- a/main/src/vtr_radar/include/vtr_radar/modules/odometry/odometry_icp_module.hpp
+++ b/main/src/vtr_radar/include/vtr_radar/modules/odometry/odometry_icp_module.hpp
@@ -79,7 +79,8 @@ class OdometryICPModule : public tactic::BaseModule {
     float min_matched_ratio = 0.4;
     float max_trans_vel_diff = 1000.0; // m/s
     float max_rot_vel_diff = 1000.0; // m/s
-    float max_transformation_diff = 1000.0; // m
+    float max_trans_diff = 1000.0; // m
+    float max_rot_diff = 1000.0; // rad
 
     bool visualize = false;
 

--- a/main/src/vtr_radar/include/vtr_radar/modules/preprocessing/conversions/offline_radar_conversion_module.hpp
+++ b/main/src/vtr_radar/include/vtr_radar/modules/preprocessing/conversions/offline_radar_conversion_module.hpp
@@ -38,14 +38,9 @@ class OfflineRadarConversionModule : public tactic::BaseModule {
   struct Config : public BaseModule::Config {
     PTR_TYPEDEFS(Config);
 
-    std::string detector = "kstrongest";
-    double minr = 2;
     double maxr = 100;
-
     double radar_resolution = 0.0438;
-    double range_offset = -0.31;
     double cart_resolution = 0.25;
-    double beta = 0.049;
     std::string chirp_type = "both";
 
     static ConstPtr fromROS(const rclcpp::Node::SharedPtr &node,

--- a/main/src/vtr_radar/include/vtr_radar/modules/preprocessing/conversions/offline_radar_conversion_module.hpp
+++ b/main/src/vtr_radar/include/vtr_radar/modules/preprocessing/conversions/offline_radar_conversion_module.hpp
@@ -41,7 +41,6 @@ class OfflineRadarConversionModule : public tactic::BaseModule {
     double cartesian_maxr = 100;  // maximum cartesian visualization distance
     double radar_resolution = 0.0438;
     double cart_resolution = 0.25;
-    std::string chirp_type = "both";
 
     static ConstPtr fromROS(const rclcpp::Node::SharedPtr &node,
                             const std::string &param_prefix);

--- a/main/src/vtr_radar/include/vtr_radar/modules/preprocessing/conversions/offline_radar_conversion_module.hpp
+++ b/main/src/vtr_radar/include/vtr_radar/modules/preprocessing/conversions/offline_radar_conversion_module.hpp
@@ -38,7 +38,7 @@ class OfflineRadarConversionModule : public tactic::BaseModule {
   struct Config : public BaseModule::Config {
     PTR_TYPEDEFS(Config);
 
-    double maxr = 100;
+    double cartesian_maxr = 100;  // maximum cartesian visualization distance
     double radar_resolution = 0.0438;
     double cart_resolution = 0.25;
     std::string chirp_type = "both";

--- a/main/src/vtr_radar/include/vtr_radar/modules/preprocessing/conversions/online_radar_conversion_module.hpp
+++ b/main/src/vtr_radar/include/vtr_radar/modules/preprocessing/conversions/online_radar_conversion_module.hpp
@@ -38,18 +38,10 @@ class OnlineRadarConversionModule : public tactic::BaseModule {
   struct Config : public BaseModule::Config {
     PTR_TYPEDEFS(Config);
 
-    double minr = 2;
     double maxr = 100;
-
     double radar_resolution = 0.0438;
-    double range_offset = -0.31;
     double cart_resolution = 0.25;
-    double beta = 0.049;
-
-    // add an encoder bin size parameter
     int encoder_bin_size = 16000;
-
-    std::string chirp_type = "both";
 
     static ConstPtr fromROS(const rclcpp::Node::SharedPtr &node,
                             const std::string &param_prefix);

--- a/main/src/vtr_radar/include/vtr_radar/modules/preprocessing/conversions/online_radar_conversion_module.hpp
+++ b/main/src/vtr_radar/include/vtr_radar/modules/preprocessing/conversions/online_radar_conversion_module.hpp
@@ -38,7 +38,7 @@ class OnlineRadarConversionModule : public tactic::BaseModule {
   struct Config : public BaseModule::Config {
     PTR_TYPEDEFS(Config);
 
-    double maxr = 100;
+    double cartesian_maxr = 100;  // maximum cartesian visualization distance
     double radar_resolution = 0.0438;
     double cart_resolution = 0.25;
     int encoder_bin_size = 16000;

--- a/main/src/vtr_radar/include/vtr_radar/modules/preprocessing/extraction/radar_extraction_module.hpp
+++ b/main/src/vtr_radar/include/vtr_radar/modules/preprocessing/extraction/radar_extraction_module.hpp
@@ -146,7 +146,6 @@ class RadarExtractionModule : public tactic::BaseModule {
     double range_offset = -0.31;
     double cart_resolution = 0.25;
     double beta = 0.049;
-    std::string chirp_type = "both";
 
     bool save_pointcloud_overlay = false;
     bool visualize = false;

--- a/main/src/vtr_radar/src/modules/odometry/odometry_icp_module.cpp
+++ b/main/src/vtr_radar/src/modules/odometry/odometry_icp_module.cpp
@@ -656,7 +656,7 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
     const auto T_r_m_prev = *qdata.T_r_m_odo;
     const auto T_r_m_query = T_r_m_eval->value();
     const auto diff_T = (T_r_m_query * T_r_m_prev.inverse()).vec().norm();
-    CLOG(WARNING, "radar.odometry_icp") << "Current Transformation difference: " << diff_T;
+    CLOG(DEBUG, "radar.odometry_icp") << "Current Transformation difference: " << diff_T;
 
     if (diff_T > config_->max_transformation_diff) {
       CLOG(WARNING, "radar.odometry_icp") << "Transformation difference between initial and final is too large: " << diff_T;

--- a/main/src/vtr_radar/src/modules/odometry/odometry_icp_module.cpp
+++ b/main/src/vtr_radar/src/modules/odometry/odometry_icp_module.cpp
@@ -85,7 +85,8 @@ auto OdometryICPModule::Config::fromROS(const rclcpp::Node::SharedPtr &node,
   config->min_matched_ratio = node->declare_parameter<float>(param_prefix + ".min_matched_ratio", config->min_matched_ratio);
   config->max_trans_vel_diff = node->declare_parameter<float>(param_prefix + ".max_trans_vel_diff", config->max_trans_vel_diff);
   config->max_rot_vel_diff = node->declare_parameter<float>(param_prefix + ".max_rot_vel_diff", config->max_rot_vel_diff);
-  config->max_transformation_diff = node->declare_parameter<float>(param_prefix + ".max_transformation_diff", config->max_transformation_diff);
+  config->max_trans_diff = node->declare_parameter<float>(param_prefix + ".max_trans_diff", config->max_trans_diff);
+  config->max_rot_diff = node->declare_parameter<float>(param_prefix + ".max_rot_diff", config->max_rot_diff);
   
   config->visualize = node->declare_parameter<bool>(param_prefix + ".visualize", config->visualize);
   // clang-format on
@@ -162,8 +163,6 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
   Time last_scan_time(static_cast<int64_t>(timestamp_odo));
   Time scan_time(static_cast<int64_t>(scan_stamp));
   Time odo_time_general(static_cast<int64_t>(timestamp_odo_general));
-
-
 
   CLOG(DEBUG, "radar.odometry_icp") << "DT current scan to last scan: " << (scan_time - last_scan_time).seconds();
   CLOG(DEBUG, "radar.odometry_icp") << "DT odometry to current scan: " << (odo_time_general - scan_time).seconds();
@@ -347,8 +346,8 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
   float mean_dR = 0;
   Eigen::MatrixXd all_tfs = Eigen::MatrixXd::Zero(4, 4);
   bool refinement_stage = false;
-  bool solver_failed = false;
   int refinement_step = 0;
+  bool solver_failed = false;
 
   CLOG(DEBUG, "radar.odometry_icp") << "Start the ICP optimization loop.";
   for (int step = 0;; step++) {
@@ -497,7 +496,7 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
     GaussNewtonSolver solver(problem, params);
     try {
       solver.optimize();
-    } catch(std::runtime_error e) {
+    } catch(const std::runtime_error& e) {
       CLOG(WARNING, "radar.odometry_icp") << "STEAM failed to solve, skipping frame. Error message: " << e.what();
       solver_failed = true;
     }
@@ -597,7 +596,8 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
     if ((refinement_stage && step >= max_it - 1) ||
         (refinement_step > config_->averaging_num_steps &&
          mean_dT < config_->trans_diff_thresh &&
-         mean_dR < config_->rot_diff_thresh)) {
+         mean_dR < config_->rot_diff_thresh) || 
+         solver_failed) {
       // result
       if (config_->use_trajectory_estimation) {
         Eigen::Matrix<double, 6, 6> T_r_m_cov = Eigen::Matrix<double, 6, 6>::Identity();
@@ -643,23 +643,31 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
   // Check if change between initial and final velocity is reasonable
   if (config_->use_trajectory_estimation) {
     const auto &w_m_r_in_r_eval_ = trajectory->getVelocityInterpolator(Time(static_cast<int64_t>(scan_stamp)))->evaluate().matrix();
-    const auto diff = w_m_r_in_r_eval_ - w_m_r_in_r_odo;
-    const auto vel_diff_norm = diff.norm();
-    const auto trans_vel_diff_norm = diff.head<3>().norm();
-    const auto rot_vel_diff_norm = diff.tail<3>().norm();
+    const auto vel_diff = w_m_r_in_r_eval_ - w_m_r_in_r_odo;
+    const auto vel_diff_norm = vel_diff.norm();
+    const auto trans_vel_diff_norm = vel_diff.head<3>().norm();
+    const auto rot_vel_diff_norm = vel_diff.tail<3>().norm();
+
+    const auto T_r_m_prev = *qdata.T_r_m_odo;
+    const auto T_r_m_query = T_r_m_eval->value();
+    const auto diff_T = (T_r_m_query.inverse() * T_r_m_prev).vec();
+    const auto diff_T_trans = diff_T.head<3>().norm();
+    const auto diff_T_rot = diff_T.tail<3>().norm();
+    
+    CLOG(DEBUG, "radar.odometry_icp") << "Current transformation difference: " << diff_T.transpose();
+    CLOG(DEBUG, "radar.odometry_icp") << "Current velocity difference: " << vel_diff.transpose();
 
     if (trans_vel_diff_norm > config_->max_trans_vel_diff || rot_vel_diff_norm > config_->max_rot_vel_diff) {
       CLOG(WARNING, "radar.odometry_icp") << "Velocity difference between initial and final is too large: " << vel_diff_norm << " translational velocity difference: " << trans_vel_diff_norm << " rotational velocity difference: " << rot_vel_diff_norm;
       estimate_reasonable = false;
     }
 
-    const auto T_r_m_prev = *qdata.T_r_m_odo;
-    const auto T_r_m_query = T_r_m_eval->value();
-    const auto diff_T = (T_r_m_query * T_r_m_prev.inverse()).vec().norm();
-    CLOG(DEBUG, "radar.odometry_icp") << "Current Transformation difference: " << diff_T;
-
-    if (diff_T > config_->max_transformation_diff) {
-      CLOG(WARNING, "radar.odometry_icp") << "Transformation difference between initial and final is too large: " << diff_T;
+    if (diff_T_trans > config_->max_trans_diff) {
+      CLOG(WARNING, "radar.odometry_icp") << "Transformation difference between initial and final translation is too large. Transform difference vector: " << diff_T.transpose();
+      estimate_reasonable = false;
+    }
+    if (diff_T_rot > config_->max_rot_diff) {
+      CLOG(WARNING, "radar.odometry_icp") << "Transformation difference between initial and final rotation is too large. Transform difference vector: " << diff_T.transpose();
       estimate_reasonable = false;
     }
   }

--- a/main/src/vtr_radar/src/modules/preprocessing/conversions/offline_radar_conversion_module.cpp
+++ b/main/src/vtr_radar/src/modules/preprocessing/conversions/offline_radar_conversion_module.cpp
@@ -19,8 +19,6 @@
  */
 #include "vtr_radar/modules/preprocessing/conversions/offline_radar_conversion_module.hpp"
 #include "cv_bridge/cv_bridge.h"
-
-#include "vtr_radar/detector/detector.hpp"
 #include "vtr_radar/utils/utils.hpp"
 
 namespace vtr {
@@ -49,16 +47,9 @@ auto OfflineRadarConversionModule::Config::fromROS(
     -> ConstPtr {
   auto config = std::make_shared<Config>();
   // clang-format off
-  config->minr = node->declare_parameter<double>(param_prefix + ".minr", config->minr);
   config->maxr = node->declare_parameter<double>(param_prefix + ".maxr", config->maxr);
-  config->range_offset = node->declare_parameter<double>(param_prefix + ".range_offset", config->range_offset);
-
-
   config->radar_resolution = node->declare_parameter<double>(param_prefix + ".radar_resolution", config->radar_resolution);
   config->cart_resolution = node->declare_parameter<double>(param_prefix + ".cart_resolution", config->cart_resolution);
-
-  // Doppler stuff
-  config->beta = node->declare_parameter<double>(param_prefix + ".beta", config->beta);
   config->chirp_type = node->declare_parameter<std::string>(param_prefix + ".chirp_type", config->chirp_type);
 
   // clang-format on

--- a/main/src/vtr_radar/src/modules/preprocessing/conversions/offline_radar_conversion_module.cpp
+++ b/main/src/vtr_radar/src/modules/preprocessing/conversions/offline_radar_conversion_module.cpp
@@ -47,7 +47,7 @@ auto OfflineRadarConversionModule::Config::fromROS(
     -> ConstPtr {
   auto config = std::make_shared<Config>();
   // clang-format off
-  config->maxr = node->declare_parameter<double>(param_prefix + ".maxr", config->maxr);
+  config->cartesian_maxr = node->declare_parameter<double>(param_prefix + ".cartesian_maxr", config->cartesian_maxr);
   config->radar_resolution = node->declare_parameter<double>(param_prefix + ".radar_resolution", config->radar_resolution);
   config->cart_resolution = node->declare_parameter<double>(param_prefix + ".cart_resolution", config->cart_resolution);
   config->chirp_type = node->declare_parameter<std::string>(param_prefix + ".chirp_type", config->chirp_type);
@@ -111,7 +111,7 @@ void OfflineRadarConversionModule::run_(QueryCache &qdata0, OutputCache &,
   load_radar(scan_use, azimuth_times, azimuth_angles, fft_scan);
 
   // Convert to cartesian BEV image
-  int cart_pixel_width = (2 * config_->maxr) / cart_resolution;
+  int cart_pixel_width = (2 * config_->cartesian_maxr) / cart_resolution;
   radar_polar_to_cartesian(fft_scan, azimuth_angles, cartesian,
                            radar_resolution, cart_resolution, cart_pixel_width,
                            true, CV_32F);

--- a/main/src/vtr_radar/src/modules/preprocessing/conversions/offline_radar_conversion_module.cpp
+++ b/main/src/vtr_radar/src/modules/preprocessing/conversions/offline_radar_conversion_module.cpp
@@ -50,7 +50,6 @@ auto OfflineRadarConversionModule::Config::fromROS(
   config->cartesian_maxr = node->declare_parameter<double>(param_prefix + ".cartesian_maxr", config->cartesian_maxr);
   config->radar_resolution = node->declare_parameter<double>(param_prefix + ".radar_resolution", config->radar_resolution);
   config->cart_resolution = node->declare_parameter<double>(param_prefix + ".cart_resolution", config->cart_resolution);
-  config->chirp_type = node->declare_parameter<std::string>(param_prefix + ".chirp_type", config->chirp_type);
 
   // clang-format on
   return config;
@@ -70,7 +69,6 @@ void OfflineRadarConversionModule::run_(QueryCache &qdata0, OutputCache &,
 #endif
 
   /// temp variables
-  cv::Mat scan_use;
   cv::Mat fft_scan;
   cv::Mat cartesian;
   std::vector<int64_t> azimuth_times;
@@ -86,29 +84,8 @@ void OfflineRadarConversionModule::run_(QueryCache &qdata0, OutputCache &,
 #endif
   float cart_resolution = config_->cart_resolution;
 
-  // Downsample scan based on desired chirp type
-  if (config_->chirp_type == "up") {
-    // Choose only every second row, starting from row 0
-    scan_use = cv::Mat::zeros(scan.rows / 2, scan.cols, cv::IMREAD_GRAYSCALE);
-    int j = 0;
-    for (int i = 0; i < scan.rows; i+=2) {
-      scan.row(i).copyTo(scan_use.row(j));
-      j++;
-    }
-  } else if (config_->chirp_type == "down") {
-    // Choose only every second row, starting from row 1
-    scan_use = cv::Mat::zeros(scan.rows / 2, scan.cols, cv::IMREAD_GRAYSCALE);
-    int j = 0;
-    for (int i = 1; i < scan.rows; i+=2) {
-      scan.row(i).copyTo(scan_use.row(i));
-      j++;
-    }
-  } else{
-    scan_use = scan;
-  }
-
   // Load scan, times, azimuths from scan
-  load_radar(scan_use, azimuth_times, azimuth_angles, fft_scan);
+  load_radar(scan, azimuth_times, azimuth_angles, fft_scan);
 
   // Convert to cartesian BEV image
   int cart_pixel_width = (2 * config_->cartesian_maxr) / cart_resolution;

--- a/main/src/vtr_radar/src/modules/preprocessing/conversions/online_radar_conversion_module.cpp
+++ b/main/src/vtr_radar/src/modules/preprocessing/conversions/online_radar_conversion_module.cpp
@@ -19,10 +19,8 @@
  */
 #include "vtr_radar/modules/preprocessing/conversions/online_radar_conversion_module.hpp"
 #include "cv_bridge/cv_bridge.h"
-#include "vtr_radar/detector/detector.hpp"
 #include "vtr_radar/utils/utils.hpp"
 #include <pcl/common/common.h>
-
 #include<vtr_radar/types.hpp>
 
 namespace vtr {
@@ -35,16 +33,13 @@ auto OnlineRadarConversionModule::Config::fromROS(
     -> ConstPtr {
   auto config = std::make_shared<Config>();
   // clang-format off
-  config->minr = node->declare_parameter<double>(param_prefix + ".minr", config->minr);
   config->maxr = node->declare_parameter<double>(param_prefix + ".maxr", config->maxr);
   config->range_offset = node->declare_parameter<double>(param_prefix + ".range_offset", config->range_offset);
   
   config->radar_resolution = node->declare_parameter<double>(param_prefix + ".radar_resolution", config->radar_resolution);
   config->cart_resolution = node->declare_parameter<double>(param_prefix + ".cart_resolution", config->cart_resolution);
-
-  // add a encoder bin size parameter
   config->encoder_bin_size = node->declare_parameter<double>(param_prefix + ".encoder_bin_size", config->encoder_bin_size);
-  
+
   // clang-format on
   return config;
 }

--- a/main/src/vtr_radar/src/modules/preprocessing/conversions/online_radar_conversion_module.cpp
+++ b/main/src/vtr_radar/src/modules/preprocessing/conversions/online_radar_conversion_module.cpp
@@ -34,7 +34,6 @@ auto OnlineRadarConversionModule::Config::fromROS(
   auto config = std::make_shared<Config>();
   // clang-format off
   config->cartesian_maxr = node->declare_parameter<double>(param_prefix + ".cartesian_maxr", config->cartesian_maxr);
-  config->range_offset = node->declare_parameter<double>(param_prefix + ".range_offset", config->range_offset);
   config->radar_resolution = node->declare_parameter<double>(param_prefix + ".radar_resolution", config->radar_resolution);
   config->cart_resolution = node->declare_parameter<double>(param_prefix + ".cart_resolution", config->cart_resolution);
   config->encoder_bin_size = node->declare_parameter<double>(param_prefix + ".encoder_bin_size", config->encoder_bin_size);

--- a/main/src/vtr_radar/src/modules/preprocessing/conversions/online_radar_conversion_module.cpp
+++ b/main/src/vtr_radar/src/modules/preprocessing/conversions/online_radar_conversion_module.cpp
@@ -33,9 +33,8 @@ auto OnlineRadarConversionModule::Config::fromROS(
     -> ConstPtr {
   auto config = std::make_shared<Config>();
   // clang-format off
-  config->maxr = node->declare_parameter<double>(param_prefix + ".maxr", config->maxr);
+  config->cartesian_maxr = node->declare_parameter<double>(param_prefix + ".cartesian_maxr", config->cartesian_maxr);
   config->range_offset = node->declare_parameter<double>(param_prefix + ".range_offset", config->range_offset);
-  
   config->radar_resolution = node->declare_parameter<double>(param_prefix + ".radar_resolution", config->radar_resolution);
   config->cart_resolution = node->declare_parameter<double>(param_prefix + ".cart_resolution", config->cart_resolution);
   config->encoder_bin_size = node->declare_parameter<double>(param_prefix + ".encoder_bin_size", config->encoder_bin_size);
@@ -82,7 +81,7 @@ void OnlineRadarConversionModule::run_(QueryCache &qdata0, OutputCache &,
   float cart_resolution = config_->cart_resolution;
 
   // Convert to cartesian BEV image
-  int cart_pixel_width = (2 * config_->maxr) / cart_resolution;
+  int cart_pixel_width = (2 * config_->cartesian_maxr) / cart_resolution;
 
   radar_polar_to_cartesian(fft_scan, azimuth_angles, cartesian,
                            radar_resolution, cart_resolution, cart_pixel_width,

--- a/main/src/vtr_radar/src/modules/preprocessing/extraction/radar_extraction_module.cpp
+++ b/main/src/vtr_radar/src/modules/preprocessing/extraction/radar_extraction_module.cpp
@@ -175,9 +175,8 @@ auto RadarExtractionModule::Config::fromROS(
   config->cart_resolution = node->declare_parameter<double>(param_prefix + ".cart_resolution", config->cart_resolution);
   config->visualize = node->declare_parameter<bool>(param_prefix + ".visualize", config->visualize);
   
-  // Doppler stuff (not used for now but may be useful in the future)
+  // Doppler stuff
   config->beta = node->declare_parameter<double>(param_prefix + ".beta", config->beta);
-  config->chirp_type = node->declare_parameter<std::string>(param_prefix + ".chirp_type", config->chirp_type);
 
   // clang-format on
   return config;

--- a/main/src/vtr_radar/src/pipeline.cpp
+++ b/main/src/vtr_radar/src/pipeline.cpp
@@ -86,7 +86,6 @@ void RadarPipeline::reset() {
   last_gyro_msg_ = nullptr;
   preint_delta_yaw_ = nullptr;
 
-
   submap_vid_odo_ = tactic::VertexId::Invalid();
   T_sv_m_odo_ = tactic::EdgeTransform(true);
   // localization cached data
@@ -128,7 +127,6 @@ void RadarPipeline::runOdometry_(const QueryCache::Ptr &qdata0,
   for (const auto &module : odometry_)
     module->run(*qdata0, *output0, graph, executor);
 
-
   // store the current sliding map for odometry
   if (qdata->sliding_map_odo) {
     sliding_map_odo_ = qdata->sliding_map_odo.ptr();
@@ -142,11 +140,9 @@ void RadarPipeline::runOdometry_(const QueryCache::Ptr &qdata0,
       T_r_m_odo_radar_ = qdata->T_r_m_odo_radar.ptr();
       w_m_r_in_r_odo_radar_ = qdata->w_m_r_in_r_odo_radar.ptr(); 
     }
-
   }
 
   // store the preintegration stuff
-
   if(qdata->stamp_start_pre_integration) preint_start_time_ = qdata->stamp_start_pre_integration.ptr();
   if(qdata->stamp_end_pre_integration) preint_end_time_ = qdata->stamp_end_pre_integration.ptr();
   if(qdata->prev_gyro_msg) last_gyro_msg_ = qdata->prev_gyro_msg.ptr();
@@ -224,7 +220,6 @@ void RadarPipeline::onVertexCreation_(const QueryCache::Ptr &qdata0,
       CLOG(DEBUG, "radar.pipeline") << "Saved radar b_scan_img to vertex" << vertex;
     }
   }
-
 
   /// save the sliding map as vertex submap if we have traveled far enough
   const bool create_submap = [&] {

--- a/main/src/vtr_radar_lidar/include/vtr_radar_lidar/pipeline.hpp
+++ b/main/src/vtr_radar_lidar/include/vtr_radar_lidar/pipeline.hpp
@@ -47,6 +47,7 @@ class RadarLidarPipeline : public tactic::BasePipeline {
     double submap_rotation_threshold = 0.0;     // in degrees
 
     bool save_raw_point_cloud = false;
+    bool save_radar_images = false;
 
     static ConstPtr fromROS(const rclcpp::Node::SharedPtr &node,
                             const std::string &param_prefix);
@@ -96,9 +97,12 @@ class RadarLidarPipeline : public tactic::BasePipeline {
   std::shared_ptr<radar::PointMap<radar::PointWithInfo>> sliding_map_odo_;
   /** \brief current timestamp*/
   std::shared_ptr<tactic::Timestamp> timestamp_odo_;
+  std::shared_ptr<tactic::Timestamp> timestamp_odo_radar_;
   /** \brief current pose and body velocity w.r.t the sliding map */
   std::shared_ptr<tactic::EdgeTransform> T_r_m_odo_;
+  std::shared_ptr<tactic::EdgeTransform> T_r_m_odo_radar_;
   std::shared_ptr<Eigen::Matrix<double, 6, 1>> w_m_r_in_r_odo_;
+  std::shared_ptr<Eigen::Matrix<double, 6, 1>> w_m_r_in_r_odo_radar_;
   /** \brief vertex id of the last submap */
   tactic::VertexId submap_vid_odo_ = tactic::VertexId::Invalid();
   /** \brief transformation from latest submap vertex to robot */
@@ -107,6 +111,12 @@ class RadarLidarPipeline : public tactic::BasePipeline {
   /// localization cached data
   /** \brief Current submap for localization */
   std::shared_ptr<const lidar::PointMap<lidar::PointWithInfo>> submap_loc_;
+
+  /// preintegration cached data
+  std::shared_ptr<tactic::Timestamp> preint_start_time_;
+  std::shared_ptr<tactic::Timestamp> preint_end_time_;
+  std::shared_ptr<sensor_msgs::msg::Imu> last_gyro_msg_;
+  std::shared_ptr<float> preint_delta_yaw_;
 
   VTR_REGISTER_PIPELINE_DEC_TYPE(RadarLidarPipeline);
 };

--- a/main/src/vtr_radar_lidar/src/pipeline.cpp
+++ b/main/src/vtr_radar_lidar/src/pipeline.cpp
@@ -74,6 +74,16 @@ void RadarLidarPipeline::reset() {
   timestamp_odo_ = nullptr;
   T_r_m_odo_ = nullptr;
   w_m_r_in_r_odo_ = nullptr;
+
+  timestamp_odo_radar_ = nullptr;
+  T_r_m_odo_radar_ = nullptr;
+  w_m_r_in_r_odo_radar_ = nullptr;
+
+  preint_start_time_ = nullptr;
+  preint_end_time_ = nullptr;
+  last_gyro_msg_ = nullptr;
+  preint_delta_yaw_ = nullptr;
+
   submap_vid_odo_ = tactic::VertexId::Invalid();
   T_sv_m_odo_ = tactic::EdgeTransform(true);
   // localization cached data
@@ -100,7 +110,17 @@ void RadarLidarPipeline::runOdometry_(const QueryCache::Ptr &qdata0,
     qdata->timestamp_odo = timestamp_odo_;
     qdata->T_r_m_odo = T_r_m_odo_;
     qdata->w_m_r_in_r_odo = w_m_r_in_r_odo_;
+
+    qdata->timestamp_odo_radar = timestamp_odo_radar_;
+    qdata->T_r_m_odo_radar = T_r_m_odo_radar_;
+    qdata->w_m_r_in_r_odo_radar = w_m_r_in_r_odo_radar_;
   }
+
+  /// Carry over preintegration stuff
+  if(preint_start_time_ != nullptr) qdata->stamp_start_pre_integration = preint_start_time_;
+  if(preint_end_time_ != nullptr) qdata->stamp_end_pre_integration = preint_end_time_;
+  if(last_gyro_msg_ != nullptr) qdata->prev_gyro_msg = last_gyro_msg_;
+  if(preint_delta_yaw_ != nullptr) qdata->preintegrated_delta_yaw = preint_delta_yaw_;
 
   for (const auto &module : odometry_)
     module->run(*qdata0, *output0, graph, executor);
@@ -111,7 +131,21 @@ void RadarLidarPipeline::runOdometry_(const QueryCache::Ptr &qdata0,
     timestamp_odo_ = qdata->timestamp_odo.ptr();
     T_r_m_odo_ = qdata->T_r_m_odo.ptr();
     w_m_r_in_r_odo_ = qdata->w_m_r_in_r_odo.ptr();
+
+    if (qdata->radar_data)
+    { 
+      timestamp_odo_radar_ = qdata->timestamp_odo_radar.ptr();
+      T_r_m_odo_radar_ = qdata->T_r_m_odo_radar.ptr();
+      w_m_r_in_r_odo_radar_ = qdata->w_m_r_in_r_odo_radar.ptr(); 
+    }
   }
+
+  // store the preintegration stuff
+
+  if(qdata->stamp_start_pre_integration) preint_start_time_ = qdata->stamp_start_pre_integration.ptr();
+  if(qdata->stamp_end_pre_integration) preint_end_time_ = qdata->stamp_end_pre_integration.ptr();
+  if(qdata->prev_gyro_msg) last_gyro_msg_ = qdata->prev_gyro_msg.ptr();
+  if(qdata->preintegrated_delta_yaw) preint_delta_yaw_ = qdata->preintegrated_delta_yaw.ptr();
 }
 
 void RadarLidarPipeline::runLocalization_(const QueryCache::Ptr &qdata0,
@@ -172,7 +206,22 @@ void RadarLidarPipeline::onVertexCreation_(const QueryCache::Ptr &qdata0,
     vertex->insert<radar::PointScan<radar::PointWithInfo>>(
         "radar_raw_point_cloud", "vtr_radar_msgs/msg/PointScan",
         raw_scan_odo_msg);
-    CLOG(DEBUG, "radar.pipeline") << "Saved raw pointcloud to vertex" << vertex;
+    CLOG(DEBUG, "radar_lidar.pipeline") << "Saved raw pointcloud to vertex" << vertex;
+  }
+
+  // to add another function to save the radar b_scan_msg to the vertex
+  // radar images
+  // check if b_scan_msg is available
+  if(qdata->scan_msg)
+  {
+    if(config_->save_radar_images)
+    {
+      using RadarBScanMsgLM = storage::LockableMessage<navtech_msgs::msg::RadarBScanMsg>;
+      auto radar_b_scan_msg_msg = std::make_shared<RadarBScanMsgLM>(qdata->scan_msg.ptr(), *qdata->stamp);
+      vertex->insert<navtech_msgs::msg::RadarBScanMsg>(
+          "radar_b_scan_img", "navtech_msgs/msg/RadarBScanMsg", radar_b_scan_msg_msg);
+      CLOG(DEBUG, "radar_lidar.pipeline") << "Saved radar b_scan_img to vertex" << vertex;
+    }
   }
 
   /// save the sliding map as vertex submap if we have traveled far enough
@@ -192,7 +241,7 @@ void RadarLidarPipeline::onVertexCreation_(const QueryCache::Ptr &qdata0,
     return false;
   }();
   if (create_submap) {
-    CLOG(DEBUG, "radar.pipeline")
+    CLOG(DEBUG, "radar_lidar.pipeline")
         << "Create a submap for vertex " << *qdata->vid_odo;
     // copy the current sliding map
     auto submap_odo = std::make_shared<radar::PointMap<radar::PointWithInfo>>(
@@ -220,7 +269,7 @@ void RadarLidarPipeline::onVertexCreation_(const QueryCache::Ptr &qdata0,
   submap_ptr->map_vid = submap_vid_odo_;
   submap_ptr->T_v_this_map = (*T_r_m_odo_) * T_sv_m_odo_.inverse();
   //
-  CLOG(DEBUG, "radar.pipeline")
+  CLOG(DEBUG, "radar_lidar.pipeline")
       << "Saving submap pointer from this vertex " << *qdata->vid_odo
       << " to map vertex " << submap_vid_odo_ << " with transform T_v_map_this "
       << submap_ptr->T_v_this_map.inverse().vec().transpose();


### PR DESCRIPTION
1. Implemented necessary changes for radar-lidar pipeline to function with new radar odometry pipeline.
2. Removed unused parameters from offline/online radar conversion and from radar extraction modules.
3. Updated maxr parameter in offline/online radar conversion module to be more descriptive (now cartesian_maxr since it is purely about visualizing the cartesian image).
4. Removed "chirp_type" option for offline radar conversion. This option allowed to select only the odd or even azimuths (by azimuth number). This was mostly implemented for Doppler development and isn't expected to ever be useful. I removed it for code cleanliness/clarity reasons.