### PR TITLE
kpeaks detector merge into radar pipeline

### DIFF
--- a/config/navtech_warthog_default.yaml
+++ b/config/navtech_warthog_default.yaml
@@ -4,31 +4,29 @@
     log_to_file: true
     log_debug: true
     log_enabled:
-      - navigation
-      - radar.pipeline
+      #- navigation
+      # - radar.pipeline
       # - navigation.sensor_input
       - radar.online_converter
       - radar.pc_extractor
       - radar.odometry_icp
-      # - radar.odometry_gyro
-      # - radar.odometry_preintegration
-      # - radar.localization_icp
+      - radar.localization_icp
       # - tactic
       # - tactic.pipeline
       # - tactic.module
       # - mpc.debug
       # - cbit.control
-      - mission.state_machine
-      - mission.server
+      #- mission.state_machine
+      #- mission.server
     robot_frame: w200_0066_base_link #w200_0066_base_link
     env_info_topic: env_info
     radar_frame: w200_0066_navtech_base # w200_0066_navtech_base #navtech_base
     radar_topic: /radar_data/b_scan_msg
     gyro_frame: w200_0066_os_imu #w200_0066_os_imu #navtech_base
     gyro_topic: /ouster/imu
-    gyro_bias:
-      z: 0.0
-    queue_size: 10
+    gyro_bias: 
+      z: 0.004203267148472062 # 0.004203267148472062
+    queue_size: 100
     graph_map:
       origin_lat: 43.7822 # UTIAS: 43.78220
       origin_lng: -79.4661 # UTIAS: -79.4661
@@ -66,8 +64,6 @@
         - extraction
         - filtering
       odometry:
-        #        - preintegration
-#- gyro # you can turn off gyro and preintegration here
         - icp
         - mapping
         - vertex_test
@@ -94,14 +90,14 @@
         # TODO: make cart_resolution an integer mult of radar_resolution
         cart_resolution: 0.2384 # m/pixel of BEV Cartesian radar image
         beta: 0.0 # Doppler correction factor (set to 0 to turn this off)
-        range_offset: -0.319910 # RAS3 range offset in meters -0.220240  -0.3088
+        range_offset: 0.0 # -0.319910 # RAS3 range offset in meters -0.220240  -0.3088
         kpeaks:
           kstrong: 4
           threshold2: 0.0
           threshold3: 0.25
         kstrongest:
-          kstrong: 3 # k-strongest per azimuth to retain was 12
-          static_threshold: 0.4
+          kstrong: 4 # k-strongest per azimuth to retain was 12
+          static_threshold: 0.3
         cen2018:
           zq: 2.5
           sigma: 8
@@ -153,29 +149,29 @@
 
         # continuous time estimation
         traj_num_extra_states: 0
-        traj_qc_diag: [1.0, 0.001, 0.0001, 0.0001, 0.0001, 0.01]
+        traj_qc_diag: [1.0, 0.001, 0.0001, 0.0001, 0.0001, 0.001]
 
         # ICP parameters # TOTUNE
-        num_threads: 8 # 8
+        num_threads: 10 # 8
         first_num_steps: 2 # 2
         initial_max_iter: 4 # 4
-        initial_max_pairing_dist: 5.0 # 5.0
-        initial_max_planar_dist: 5.0 # 5.0
-        refined_max_iter: 25
-        refined_max_pairing_dist: 5.0 # 5.0
-        refined_max_planar_dist: 5.0 # 5.0
+        initial_max_pairing_dist: 1.5 # 5.0 # now same as lidar
+        initial_max_planar_dist: 1.0 # 5.0
+        refined_max_iter: 50 # 50
+        refined_max_pairing_dist: 1.0 # 5.0
+        refined_max_planar_dist: 0.3 # 5.0
         averaging_num_steps: 5 # 5
         huber_delta: 1.0 # 1.0
-        cauchy_k: 0.8
+        cauchy_k: 0.2 # was 0.8
         remove_orientation: false
 
         # steam parameters #TOTUNE
         verbose: false
         max_iterations: 1
-        gyro_cov: 1e-4
+        # gyro_cov: 1e-4
 
         # threshold #TOTUNE
-        min_matched_ratio: 0.0
+        min_matched_ratio: 0.40
 
         visualize: true
 
@@ -194,7 +190,7 @@
       vertex_test:
         type: radar.vertex_test
 
-        max_translation: 0.3
+        max_translation: 0.2
         max_rotation: 10.0
 
       memory:
@@ -215,24 +211,24 @@
 
         use_pose_prior: true
         # ICP parameters #TO TUNE
-        num_threads: 8 # 8
+        num_threads: 10 # 8
         first_num_steps: 4 # 2
         initial_max_iter: 8 # 4
-        initial_max_pairing_dist: 5.0 # 5.0
-        initial_max_planar_dist: 5.0 # 5.0
-        refined_max_iter: 25 # 50
-        refined_max_pairing_dist: 5.0 # 5.0
-        refined_max_planar_dist: 5.0 # 5.0
+        initial_max_pairing_dist: 1.5 # 5.0
+        initial_max_planar_dist: 1.0 # 5.0
+        refined_max_iter: 50 # 50
+        refined_max_pairing_dist: 1.0 # 5.0
+        refined_max_planar_dist: 0.3 # 5.0
         averaging_num_steps: 5 # 5
         huber_delta: 1.0 # 1.0
-        cauchy_k: 1.0
+        cauchy_k: 0.2
 
         # steam parameters #TOTUNE
         verbose: false
-        max_iterations: 1
+        max_iterations: 3
 
         # threshold #TOTUNE
-        min_matched_ratio: 0.3
+        min_matched_ratio: 0.30
 
       memory:
         type: "graph_mem_manager"

--- a/config/navtech_warthog_default.yaml
+++ b/config/navtech_warthog_default.yaml
@@ -83,18 +83,22 @@
     preprocessing:
       conversion:
         type: radar.online_converter
-        radar_resolution: 0.161231
+        radar_resolution: 0.040308
         encoder_bin_size: 16000 # encoder bin size
       extraction:
         type: radar.pc_extractor
-        radar_resolution: 0.161231 # 0307827  # RAS3 0.161231 #0.044
-        detector: kstrongest #modified_cacfar # choose detector \in (kstrongest, cen2018, cacfar, oscfar, modified_cacfar,caso_cfar)
+        radar_resolution: 0.040308 # 0307827  # RAS3 0.161231 #0.044
+        detector: kpeaks #modified_cacfar # choose detector \in (kstrongest, cen2018, cacfar, oscfar, modified_cacfar,caso_cfar)
         minr: 2.0 # mininum detection distance
-        maxr: 80.0 # maximum detection distance
+        maxr: 69.0 # maximum detection distance
         # TODO: make cart_resolution an integer mult of radar_resolution
         cart_resolution: 0.2384 # m/pixel of BEV Cartesian radar image
         beta: 0.0 # Doppler correction factor (set to 0 to turn this off)
         range_offset: -0.319910 # RAS3 range offset in meters -0.220240  -0.3088
+        kpeaks:
+          kstrong: 4
+          threshold2: 0.0
+          threshold3: 0.25
         kstrongest:
           kstrong: 3 # k-strongest per azimuth to retain was 12
           static_threshold: 0.4

--- a/main/src/vtr_radar/include/vtr_radar/detector/detector.hpp
+++ b/main/src/vtr_radar/include/vtr_radar/detector/detector.hpp
@@ -39,6 +39,34 @@
                     const std::vector<bool> &up_chirps,
                     pcl::PointCloud<PointT> &pointcloud) = 0;
  };
+
+ // added k-peaks detector here 
+template <class PointT>
+class KPeaks : public Detector<PointT> {
+ public:
+  KPeaks() = default;
+  KPeaks(int kstrong, double threshold2, double threshold3, double minr,
+             double maxr, double range_offset)
+      : kstrong_(kstrong),
+        threshold2_(threshold2),
+        threshold3_(threshold3),
+        minr_(minr),
+        maxr_(maxr),
+        range_offset_(range_offset) {}
+  void run(const cv::Mat &raw_scan, const float &res,
+           const std::vector<int64_t> &azimuth_times,
+           const std::vector<double> &azimuth_angles,
+           const std::vector<bool> &up_chirps,
+           pcl::PointCloud<PointT> &pointcloud) override;
+ private:
+  int kstrong_ = 10;
+  double threshold2_ = 0;
+  double threshold3_ = 0.22;
+  double minr_ = 1.0;
+  double maxr_ = 69.0;
+  double res_ = 0.040308 ;
+  double range_offset_ = -0.319910 ;
+};
  
  template <class PointT>
  class KStrongest : public Detector<PointT> {

--- a/main/src/vtr_radar/include/vtr_radar/modules/preprocessing/extraction/radar_extraction_module.hpp
+++ b/main/src/vtr_radar/include/vtr_radar/modules/preprocessing/extraction/radar_extraction_module.hpp
@@ -40,10 +40,15 @@ class RadarExtractionModule : public tactic::BaseModule {
   struct Config : public BaseModule::Config {
     PTR_TYPEDEFS(Config);
 
-    std::string detector = "kstrongest";
-    double minr = 2;
-    double maxr = 100;
-
+    std::string detector = "kpeaks";
+    double minr = 1;
+    double maxr = 69;
+    // kpeaks
+    struct {
+      int kstrong = 4;
+      double threshold2 = 0.5;
+      double threshold3 = 0.22;
+    } kpeaks;
     // kstrongest
     struct {
       int kstrong = 10;

--- a/main/src/vtr_radar/src/modules/preprocessing/extraction/radar_extraction_module.cpp
+++ b/main/src/vtr_radar/src/modules/preprocessing/extraction/radar_extraction_module.cpp
@@ -102,6 +102,12 @@ auto RadarExtractionModule::Config::fromROS(
   config->range_offset = node->declare_parameter<double>(param_prefix + ".range_offset", config->range_offset);
   config->save_pointcloud_overlay = node->declare_parameter<bool>(param_prefix + ".save_pointcloud_overlay", config->save_pointcloud_overlay);
 
+  // best decttector kpeaks
+  // kpeaks
+  config->kpeaks.kstrong = node->declare_parameter<int>(param_prefix + ".kpeaks.kstrong", config->kpeaks.kstrong);
+  config->kpeaks.threshold2 = node->declare_parameter<double>(param_prefix + ".kpeaks.threshold2", config->kpeaks.threshold2);
+  config->kpeaks.threshold3 = node->declare_parameter<double>(param_prefix + ".kpeaks.threshold3", config->kpeaks.threshold3);
+
   config->kstrongest.kstrong = node->declare_parameter<int>(param_prefix + ".kstrongest.kstrong", config->kstrongest.kstrong);
   config->kstrongest.static_threshold = node->declare_parameter<double>(param_prefix + ".kstrongest.static_threshold", config->kstrongest.static_threshold);
 
@@ -239,7 +245,14 @@ void RadarExtractionModule::run_(QueryCache &qdata0, OutputCache &,
         config_->maxr, config_->range_offset);
     detector.run(fft_scan, radar_resolution, azimuth_times, azimuth_angles, up_chirps,
                  raw_point_cloud);
-  } else if (config_->detector == "kstrongest") {
+  } else if (config_->detector == "kpeaks") {
+    KPeaks detector = KPeaks<PointWithInfo>(
+        config_->kpeaks.kstrong, config_->kpeaks.threshold2,
+        config_->kpeaks.threshold3, config_->minr, config_->maxr,
+        config_->range_offset);
+    detector.run(fft_scan, radar_resolution, azimuth_times, azimuth_angles,up_chirps,
+                 raw_point_cloud);
+  }else if (config_->detector == "kstrongest") {
     KStrongest detector = KStrongest<PointWithInfo>(
         config_->kstrongest.kstrong, config_->kstrongest.static_threshold,
         config_->minr, config_->maxr, config_->range_offset);


### PR DESCRIPTION
Added the k-peaks detector in the radar pipeline
This detector does peaking average so that the range of the points is more accurate
Scale of the odometry is preserved (tested in closed-loop)