### PR TITLE
Change Initialization Behaviour

### DIFF
--- a/config/navtech_warthog_default.yaml
+++ b/config/navtech_warthog_default.yaml
@@ -4,22 +4,20 @@
     log_to_file: true
     log_debug: true
     log_enabled:
-      - navigation
+      #- navigation
       - radar.pipeline
       # - navigation.sensor_input
       - radar.online_converter
       - radar.pc_extractor
       - radar.odometry_icp
-      # - radar.odometry_gyro
-      # - radar.odometry_preintegration
-      # - radar.localization_icp
+      - radar.localization_icp
       # - tactic
       # - tactic.pipeline
-      # - tactic.module
+      - tactic.module
       # - mpc.debug
       # - cbit.control
-      - mission.state_machine
-      - mission.server
+      #- mission.state_machine
+      #- mission.server
     robot_frame: w200_0066_base_link #w200_0066_base_link
     env_info_topic: env_info
     radar_frame: w200_0066_navtech_base # w200_0066_navtech_base #navtech_base
@@ -66,8 +64,6 @@
         - extraction
         - filtering
       odometry:
-        #        - preintegration
-#- gyro # you can turn off gyro and preintegration here
         - icp
         - mapping
         - vertex_test
@@ -83,11 +79,11 @@
     preprocessing:
       conversion:
         type: radar.online_converter
-        radar_resolution: 0.161231
+        radar_resolution: 0.044
         encoder_bin_size: 16000 # encoder bin size
       extraction:
         type: radar.pc_extractor
-        radar_resolution: 0.161231 # 0307827  # RAS3 0.161231 #0.044
+        radar_resolution: 0.044 # 0307827  # RAS3 0.161231 #0.044
         detector: kstrongest #modified_cacfar # choose detector \in (kstrongest, cen2018, cacfar, oscfar, modified_cacfar,caso_cfar)
         minr: 2.0 # mininum detection distance
         maxr: 80.0 # maximum detection distance
@@ -96,8 +92,8 @@
         beta: 0.0 # Doppler correction factor (set to 0 to turn this off)
         range_offset: -0.319910 # RAS3 range offset in meters -0.220240  -0.3088
         kstrongest:
-          kstrong: 3 # k-strongest per azimuth to retain was 12
-          static_threshold: 0.4
+          kstrong: 4 # k-strongest per azimuth to retain was 12
+          static_threshold: 0.3
         cen2018:
           zq: 2.5
           sigma: 8

--- a/main/src/vtr_lidar/src/modules/localization/localization_icp_module.cpp
+++ b/main/src/vtr_lidar/src/modules/localization/localization_icp_module.cpp
@@ -211,7 +211,7 @@ void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &output,
     problem.addStateVariable(T_r_v_var);
 
     // add prior cost terms
-    if (config_->use_pose_prior) problem.addCostTerm(prior_cost_term);
+    if (prior_cost_term != nullptr) problem.addCostTerm(prior_cost_term);
 
     // shared loss function
     auto loss_func = L2LossFunc::MakeShared();

--- a/main/src/vtr_lidar/src/modules/localization/localization_icp_module.cpp
+++ b/main/src/vtr_lidar/src/modules/localization/localization_icp_module.cpp
@@ -98,7 +98,7 @@ void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &output,
 
   /// use odometry as a prior
   WeightedLeastSqCostTerm<6>::Ptr prior_cost_term = nullptr;
-  if (config_->use_pose_prior && *qdata.odo_success) {
+  if (config_->use_pose_prior && *qdata.odo_success && output.chain->isLocalized()) {
     auto loss_func = L2LossFunc::MakeShared();
     auto noise_model = StaticNoiseModel<6>::MakeShared(T_r_v.cov());
     auto T_r_v_meas = SE3StateVar::MakeShared(T_r_v); T_r_v_meas->locked() = true;

--- a/main/src/vtr_radar/src/modules/localization/localization_icp_module.cpp
+++ b/main/src/vtr_radar/src/modules/localization/localization_icp_module.cpp
@@ -209,7 +209,7 @@ void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &output,
     problem.addStateVariable(T_r_v_var);
 
     // add prior cost terms
-    if (config_->use_pose_prior) problem.addCostTerm(prior_cost_term);
+    if (prior_cost_term != nullptr) problem.addCostTerm(prior_cost_term);
 
     // shared loss function
     // auto loss_func = HuberLossFunc::MakeShared(config_->huber_delta);

--- a/main/src/vtr_radar/src/modules/localization/localization_icp_module.cpp
+++ b/main/src/vtr_radar/src/modules/localization/localization_icp_module.cpp
@@ -56,7 +56,7 @@ auto LocalizationICPModule::Config::fromROS(const rclcpp::Node::SharedPtr &node,
   return config;
 }
 
-void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &,
+void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &output,
                                  const Graph::Ptr &,
                                  const TaskExecutor::Ptr &) {
   auto &qdata = dynamic_cast<RadarQueryCache &>(qdata0);
@@ -96,7 +96,7 @@ void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &,
 
   /// use odometry as a prior
   WeightedLeastSqCostTerm<6>::Ptr prior_cost_term = nullptr;
-  if (config_->use_pose_prior) {
+  if (config_->use_pose_prior && output.chain->isLocalized()) {
     auto loss_func = L2LossFunc::MakeShared();
     auto noise_model = StaticNoiseModel<6>::MakeShared(T_r_v.cov());
     auto T_r_v_meas = SE3StateVar::MakeShared(T_r_v); T_r_v_meas->locked() = true;

--- a/main/src/vtr_radar_lidar/src/modules/localization/localization_icp_module.cpp
+++ b/main/src/vtr_radar_lidar/src/modules/localization/localization_icp_module.cpp
@@ -61,7 +61,7 @@ auto LocalizationICPModule::Config::fromROS(const rclcpp::Node::SharedPtr &node,
   return config;
 }
 
-void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &,
+void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &output,
                                  const Graph::Ptr &,
                                  const TaskExecutor::Ptr &) {
   auto &radar_qdata = dynamic_cast<radar::RadarQueryCache &>(qdata0);
@@ -207,7 +207,7 @@ void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &,
 
   /// use odometry as a prior
   WeightedLeastSqCostTerm<6>::Ptr prior_cost_term = nullptr;
-  if (config_->use_pose_prior) {
+  if (config_->use_pose_prior && output.chain->isLocalized()) {
     auto loss_func = L2LossFunc::MakeShared();
     auto noise_model = StaticNoiseModel<6>::MakeShared(T_r_v.cov());
     auto T_r_v_meas = SE3StateVar::MakeShared(T_r_v); T_r_v_meas->locked() = true;

--- a/main/src/vtr_radar_lidar/src/modules/localization/localization_icp_module.cpp
+++ b/main/src/vtr_radar_lidar/src/modules/localization/localization_icp_module.cpp
@@ -320,7 +320,7 @@ void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &output,
     problem.addStateVariable(T_r_v_var);
 
     // add prior cost terms
-    if (config_->use_pose_prior) problem.addCostTerm(prior_cost_term);
+    if (prior_cost_term != nullptr) problem.addCostTerm(prior_cost_term);
 
     // shared loss function
     // auto loss_func = HuberLossFunc::MakeShared(config_->huber_delta);


### PR DESCRIPTION
If `use_pose_prior` is set to true in any of the ICP localization pipelines, then we use the output of odometry as a prior during the optimization. 

However, if we have not localized yet, which is always true on the first frame, odometry will have a value of identity and a small covariance because it has not moved yet. 

This effectively adds a prior that we are starting on the path, even though we don't have any evidence of this yet. 

I propose removing the prior until we successfully localize and then returning to the existing behaviour. 