### PR TITLE
Fixing import order for vtr_vision to resolve ambiguiy in namespace.

### DIFF
--- a/main/src/vtr_vision/include/vtr_vision/cache.hpp
+++ b/main/src/vtr_vision/include/vtr_vision/cache.hpp
@@ -20,8 +20,13 @@
  */
 #pragma once
 
-#include "sensor_msgs/msg/image.hpp"
+// Include PyTorch headers FIRST to avoid namespace conflicts with ROS/std
+#ifdef VTR_VISION_LEARNED
+#include <torch/script.h>
+#include <torch/torch.h>
+#endif
 
+#include "sensor_msgs/msg/image.hpp"
 
 #include <vtr_tactic/cache.hpp>
 #include <vtr_tactic/types.hpp>

--- a/main/src/vtr_vision/include/vtr_vision/modules/bundle_adjustment/stereo_windowed_recall_module.hpp
+++ b/main/src/vtr_vision/include/vtr_vision/modules/bundle_adjustment/stereo_windowed_recall_module.hpp
@@ -20,9 +20,17 @@
  */
 #pragma once
 
-#include <vtr_tactic/modules/base_module.hpp>
+// Include PyTorch headers FIRST to avoid namespace conflicts with ROS/std
+#ifdef VTR_VISION_LEARNED
+#include <torch/script.h>
+#include <torch/torch.h>
+#endif
+
 #include <vtr_vision/cache.hpp>
 #include <vtr_vision/types.hpp>
+
+// Now include other VTR headers
+#include <vtr_tactic/modules/base_module.hpp>
 #include <vtr_vision/messages/bridge.hpp>
 #include <vtr_common_msgs/msg/velocity.hpp>
 

--- a/main/src/vtr_vision/include/vtr_vision/modules/localization/experience_triage_module.hpp
+++ b/main/src/vtr_vision/include/vtr_vision/modules/localization/experience_triage_module.hpp
@@ -20,6 +20,13 @@
  */
 #pragma once
 
+// Include PyTorch headers FIRST to avoid namespace conflicts with ROS/std
+#ifdef VTR_VISION_LEARNED
+#include <torch/script.h>
+#include <torch/torch.h>
+#endif
+
+// Now include other headers
 #include <vtr_vision_msgs/msg/exp_recog_status.hpp>
 #include <vtr_tactic/modules/base_module.hpp>
 #include <vtr_vision/cache.hpp>

--- a/main/src/vtr_vision/include/vtr_vision/modules/localization/sub_map_extraction_module.hpp
+++ b/main/src/vtr_vision/include/vtr_vision/modules/localization/sub_map_extraction_module.hpp
@@ -20,6 +20,12 @@
  */
 #pragma once
 
+// Include PyTorch headers FIRST to avoid namespace conflicts with ROS/std
+#ifdef VTR_VISION_LEARNED
+#include <torch/script.h>
+#include <torch/torch.h>
+#endif
+
 #include <vtr_tactic/modules/base_module.hpp>
 #include <vtr_vision/cache.hpp>
 

--- a/main/src/vtr_vision/include/vtr_vision/modules/odometry/asrl_stereo_matcher_module.hpp
+++ b/main/src/vtr_vision/include/vtr_vision/modules/odometry/asrl_stereo_matcher_module.hpp
@@ -20,6 +20,13 @@
  */
 #pragma once
 
+// Include PyTorch headers FIRST to avoid namespace conflicts with ROS/std
+#ifdef VTR_VISION_LEARNED
+#include <torch/script.h>
+#include <torch/torch.h>
+#endif
+
+// Now include other VTR headers
 #include <vtr_tactic/modules/base_module.hpp>
 #include <vtr_vision/cache.hpp>
 #include <vtr_vision/features/matcher/asrl_feature_matcher.hpp>

--- a/main/src/vtr_vision/include/vtr_vision/modules/odometry/landmark_recall_module.hpp
+++ b/main/src/vtr_vision/include/vtr_vision/modules/odometry/landmark_recall_module.hpp
@@ -20,8 +20,16 @@
  */
 #pragma once
 
-#include <vtr_tactic/modules/base_module.hpp>
+// Include PyTorch headers FIRST to avoid namespace conflicts with ROS/std
+#ifdef VTR_VISION_LEARNED
+#include <torch/script.h>
+#include <torch/torch.h>
+#endif
+
 #include <vtr_vision/cache.hpp>
+
+// Now include other VTR headers
+#include <vtr_tactic/modules/base_module.hpp>
 #include <vtr_vision/messages/bridge.hpp>
 #include "vtr_common/conversions/ros_lgmath.hpp"
 

--- a/main/src/vtr_vision/include/vtr_vision/modules/odometry/simple_vertex_test_module.hpp
+++ b/main/src/vtr_vision/include/vtr_vision/modules/odometry/simple_vertex_test_module.hpp
@@ -20,8 +20,16 @@
  */
 #pragma once
 
-#include <vtr_tactic/modules/base_module.hpp>
+// Include PyTorch headers FIRST to avoid namespace conflicts with ROS/std
+#ifdef VTR_VISION_LEARNED
+#include <torch/script.h>
+#include <torch/torch.h>
+#endif
+
 #include <vtr_vision/cache.hpp>
+
+// Now include other VTR headers
+#include <vtr_tactic/modules/base_module.hpp>
 
 namespace vtr {
 namespace vision {

--- a/main/src/vtr_vision/include/vtr_vision/modules/optimization/keyframe_optimization_module.hpp
+++ b/main/src/vtr_vision/include/vtr_vision/modules/optimization/keyframe_optimization_module.hpp
@@ -20,6 +20,12 @@
  */
 #pragma once
 
+// Include PyTorch headers FIRST to avoid namespace conflicts with ROS/std
+#ifdef VTR_VISION_LEARNED
+#include <torch/script.h>
+#include <torch/torch.h>
+#endif
+
 #include <lgmath.hpp>
 #include <steam.hpp>
 

--- a/main/src/vtr_vision/include/vtr_vision/modules/optimization/steam_module.hpp
+++ b/main/src/vtr_vision/include/vtr_vision/modules/optimization/steam_module.hpp
@@ -20,11 +20,18 @@
  */
 #pragma once
 
-#include <lgmath.hpp>
-#include <steam.hpp>
+// Include PyTorch headers FIRST to avoid namespace conflicts with ROS/std
+#ifdef VTR_VISION_LEARNED
+#include <torch/script.h>
+#include <torch/torch.h>
+#endif
 
+// Now include other headers
 #include <vtr_tactic/modules/base_module.hpp>
 #include <vtr_vision/cache.hpp>
+
+#include <lgmath.hpp>
+#include <steam.hpp>
 
 namespace vtr {
 namespace vision {

--- a/main/src/vtr_vision/include/vtr_vision/modules/preprocessing/calibration_module.hpp
+++ b/main/src/vtr_vision/include/vtr_vision/modules/preprocessing/calibration_module.hpp
@@ -20,6 +20,12 @@
  */
 #pragma once
 
+// Include PyTorch headers FIRST to avoid namespace conflicts with ROS/std
+#ifdef VTR_VISION_LEARNED
+#include <torch/script.h>
+#include <torch/torch.h>
+#endif
+
 #include <vtr_tactic/modules/base_module.hpp>
 #include <vtr_vision/cache.hpp>
 #include <vtr_tactic/cache.hpp>

--- a/main/src/vtr_vision/include/vtr_vision/modules/ransac/ransac_module.hpp
+++ b/main/src/vtr_vision/include/vtr_vision/modules/ransac/ransac_module.hpp
@@ -20,6 +20,12 @@
  */
 #pragma once
 
+// Include PyTorch headers FIRST to avoid namespace conflicts with ROS/std
+#ifdef VTR_VISION_LEARNED
+#include <torch/script.h>
+#include <torch/torch.h>
+#endif
+
 #include <vtr_tactic/modules/base_module.hpp>
 #include <vtr_vision/cache.hpp>
 #include <vtr_vision/outliers.hpp>

--- a/main/src/vtr_vision/include/vtr_vision/modules/ransac/stereo_ransac_module.hpp
+++ b/main/src/vtr_vision/include/vtr_vision/modules/ransac/stereo_ransac_module.hpp
@@ -20,6 +20,12 @@
  */
 #pragma once
 
+// Include PyTorch headers FIRST to avoid namespace conflicts with ROS/std
+#ifdef VTR_VISION_LEARNED
+#include <torch/script.h>
+#include <torch/torch.h>
+#endif
+
 #include <random>
 
 #include <vtr_tactic/modules/base_module.hpp>


### PR DESCRIPTION
Fixing issue where `optional` and `nullopt` defs would be ambiguous on account of being defined by both torch and from some ROS headers. Switching the import order resolves the problem, but I am unsure if this is the best way to do it. I have also not tested the vision pipeline with these changes.

Here is a failed build on account of this issue: https://github.com/utiasASRL/vtr3/actions/runs/18047949533/job/51363210471 