### PR TITLE
Radar arbitrary frame fix

### DIFF
--- a/main/src/vtr_radar/src/modules/localization/localization_icp_module.cpp
+++ b/main/src/vtr_radar/src/modules/localization/localization_icp_module.cpp
@@ -92,10 +92,9 @@ void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &output,
   // We want to run ICP in the sensor frame to do proper SE(2)
   // We thus transform both the vertex and robot frame into the radar frame and do ICP there.
   // The final result can then be easily transformed back to the vertex frame.
-  const auto T_vs_m = T_s_r * T_v_m;
-  const auto T_s_vs = T_s_r * T_r_v * T_s_r.inverse();
   // Note that T_s_vs may not be perfectly 2D, but we chop off the 2D parts since for radar-only
   // estimation it is impossible for us to observe a full 3D pose
+  const auto T_s_vs = T_s_r * T_r_v * T_s_r.inverse();
   const auto T_s_vs_2d = T_s_vs.toSE2();
 
   /// Parameters
@@ -125,22 +124,29 @@ void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &output,
   pcl::PointCloud<PointWithInfo> aligned_points(query_points);
 
   /// Eigen matrix of original data (only shallow copy of ref clouds)
-  const auto map_mat = point_map.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::cartesian_offset());
   const auto query_mat = query_points.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::cartesian_offset());
   auto aligned_mat = aligned_points.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::cartesian_offset());
 
+  /// Deep copy of map points (since we will be transforming them for matching)
+  pcl::PointCloud<PointWithInfo> point_map_copy(point_map);
+  auto map_mat = point_map_copy.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::cartesian_offset());
+
+  // Transform point map (currently in map frame m) into vertex sensor frame (vs) for matching.
+  const auto T_vs_m = T_s_r * T_v_m;
+  const auto T_vs_m_mat_f = T_vs_m.matrix().cast<float>();
+  map_mat = T_vs_m_mat_f * map_mat;
+
   /// create kd-tree of the map
   CLOG(DEBUG, "radar.localization_icp") << "Start building a kd-tree of the map.";
-  NanoFLANNAdapter<PointWithInfo> adapter(point_map);
+  NanoFLANNAdapter<PointWithInfo> adapter(point_map_copy);
   KDTreeParams tree_params(/* max leaf */ 10);
   auto kdtree = std::make_unique<KDTree<PointWithInfo>>(3, adapter, tree_params);
   kdtree->buildIndex();
 
   /// perform initial alignment
   {
-    const auto T_s_m = T_s_vs_var->evaluate().toSE3() * T_vs_m;
-    const auto T_s_m_mat_f = T_s_m.inverse().matrix().cast<float>();
-    aligned_mat = T_s_m_mat_f * query_mat;
+    const auto T_vs_s_mat_f = T_s_vs_var->evaluate().toSE3().inverse().matrix().cast<float>();
+    aligned_mat = T_vs_s_mat_f * query_mat;
   }
 
   using Stopwatch = common::timing::Stopwatch<>;
@@ -227,14 +233,8 @@ void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &output,
 
       // query and reference point
       const auto qry_pt = query_mat.block<2, 1>(0, ind.first).cast<double>();
-      const auto ref_pt_vs = T_vs_m * map_mat.block<4, 1>(0, ind.second).cast<double>();
-      const auto ref_pt = ref_pt_vs.block<2, 1>(0, 0);
+      const auto ref_pt = map_mat.block<2, 1>(0, ind.second).cast<double>();
       const auto error_func = p2p::p2pSE2Error(T_vs_s_eval, ref_pt, qry_pt);
-
-      if (step == 0 && ind.first == 0) {
-        CLOG(DEBUG, "radar.localization_icp") << "First query point: " <<  query_mat.block<4, 1>(0, ind.first).transpose();
-        CLOG(DEBUG, "radar.localization_icp") << "First reference point: " << ref_pt_vs.transpose();
-      }
 
       // create cost term and add to problem
       auto cost = WeightedLeastSqCostTerm<2>::MakeShared(error_func, noise_model, loss_func);
@@ -255,9 +255,8 @@ void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &output,
     /// Alignment
     timer[4]->start();
     {
-      const auto T_s_m = T_s_vs_var->evaluate().toSE3() * T_vs_m;
-      const auto T_s_m_mat_f = T_s_m.inverse().matrix().cast<float>();
-      aligned_mat = T_s_m_mat_f * query_mat;
+      const auto T_vs_s_mat_f = T_s_vs_var->evaluate().toSE3().inverse().matrix().cast<float>();
+      aligned_mat = T_vs_s_mat_f * query_mat;
     }
 
     // Update all result matrices

--- a/main/src/vtr_radar/src/modules/localization/localization_icp_module.cpp
+++ b/main/src/vtr_radar/src/modules/localization/localization_icp_module.cpp
@@ -128,11 +128,8 @@ void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &output,
 
   /// Eigen matrix of original data (only shallow copy of ref clouds)
   const auto map_mat = point_map.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::cartesian_offset());
-  // const auto map_normals_mat = point_map.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::normal_offset());
   const auto query_mat = query_points.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::cartesian_offset());
-  const auto query_norms_mat = query_points.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::normal_offset());
   auto aligned_mat = aligned_points.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::cartesian_offset());
-  auto aligned_norms_mat = aligned_points.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::normal_offset());
 
   /// create kd-tree of the map
   CLOG(DEBUG, "radar.localization_icp") << "Start building a kd-tree of the map.";
@@ -145,7 +142,6 @@ void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &output,
   {
     const auto T_m_s = T_m_s_eval->evaluate().toSE3().matrix().cast<float>();
     aligned_mat = T_m_s * query_mat;
-    aligned_norms_mat = T_m_s * query_norms_mat;
   }
 
   using Stopwatch = common::timing::Stopwatch<>;
@@ -256,7 +252,6 @@ void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &output,
     {
       const auto T_m_s = T_m_s_eval->evaluate().toSE3().matrix().cast<float>();
       aligned_mat = T_m_s * query_mat;
-      aligned_norms_mat = T_m_s * query_norms_mat;
     }
 
     // Update all result matrices

--- a/main/src/vtr_radar/src/modules/localization/localization_icp_module.cpp
+++ b/main/src/vtr_radar/src/modules/localization/localization_icp_module.cpp
@@ -89,10 +89,14 @@ void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &output,
   // const auto &map_version = qdata.submap_loc->version();
   auto &point_map = qdata.submap_loc->point_cloud();
 
-  // Extract 2D transforms
-  const lgmath::se2::Transformation T_s_r_2d = T_s_r.toSE2();
-  const lgmath::se2::Transformation T_r_v_2d = T_r_v.toSE2();
-  const lgmath::se2::Transformation T_v_m_2d = T_v_m.toSE2();
+  // We want to run ICP in the sensor frame to do proper SE(2)
+  // We thus transform both the vertex and robot frame into the radar frame and do ICP there.
+  // The final result can then be easily transformed back to the vertex frame.
+  const auto T_vs_m = T_s_r * T_v_m;
+  const auto T_s_vs = T_s_r * T_r_v * T_s_r.inverse();
+  // Note that T_s_vs may not be perfectly 2D, but we chop off the 2D parts since for radar-only
+  // estimation it is impossible for us to observe a full 3D pose
+  const auto T_s_vs_2d = T_s_vs.toSE2();
 
   /// Parameters
   int first_steps = config_->first_num_steps;
@@ -103,25 +107,19 @@ void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &output,
   KDTreeSearchParams search_params;
 
   // clang-format off
-  /// Create robot to sensor transform variable, fixed.
-  const auto T_s_r_var = SE2StateVar::MakeShared(T_s_r_2d); T_s_r_var->locked() = true;
-  const auto T_v_m_var = SE2StateVar::MakeShared(T_v_m_2d); T_v_m_var->locked() = true;
-
   /// Create and add the T_robot_map variable, here m = vertex frame.
-  const auto T_r_v_var = SE2StateVar::MakeShared(T_r_v_2d);
+  const auto T_s_vs_var = SE2StateVar::MakeShared(T_s_vs_2d);
+  const auto T_vs_s_eval = inverse(T_s_vs_var);
 
   /// use odometry as a prior
   WeightedLeastSqCostTerm<3>::Ptr prior_cost_term = nullptr;
   if (config_->use_pose_prior && output.chain->isLocalized()) {
     auto loss_func = L2LossFunc::MakeShared();
-    auto noise_model = StaticNoiseModel<3>::MakeShared(cov3Dto2D(T_r_v.cov()));
-    auto T_r_v_meas = SE2StateVar::MakeShared(T_r_v_2d); T_r_v_meas->locked() = true;
-    auto error_func = tran2vec(compose(T_r_v_meas, inverse(T_r_v_var)));
+    auto noise_model = StaticNoiseModel<3>::MakeShared(cov3Dto2D(T_s_vs.cov()));
+    auto T_s_vs_meas = SE2StateVar::MakeShared(T_s_vs_2d); T_s_vs_meas->locked() = true;
+    auto error_func = tran2vec(compose(T_s_vs_meas, inverse(T_s_vs_var)));
     prior_cost_term = WeightedLeastSqCostTerm<3>::MakeShared(error_func, noise_model, loss_func);
   }
-
-  /// compound transform for alignment (sensor to point map transform)
-  const auto T_m_s_eval = inverse(compose(T_s_r_var, compose(T_r_v_var, T_v_m_var)));
 
   /// Initialize aligned points for matching (Deep copy of targets)
   pcl::PointCloud<PointWithInfo> aligned_points(query_points);
@@ -140,8 +138,9 @@ void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &output,
 
   /// perform initial alignment
   {
-    const auto T_m_s = T_m_s_eval->evaluate().toSE3().matrix().cast<float>();
-    aligned_mat = T_m_s * query_mat;
+    const auto T_s_m = T_s_vs_var->evaluate().toSE3() * T_vs_m;
+    const auto T_s_m_mat_f = T_s_m.inverse().matrix().cast<float>();
+    aligned_mat = T_s_m_mat_f * query_mat;
   }
 
   using Stopwatch = common::timing::Stopwatch<>;
@@ -163,6 +162,7 @@ void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &output,
   timer.emplace_back(std::make_unique<Stopwatch>(false));
 
   // ICP results
+  EdgeTransform T_s_vs_icp;
   EdgeTransform T_r_v_icp;
   float matched_points_ratio = 0.0;
 
@@ -211,7 +211,7 @@ void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &output,
     OptimizationProblem problem(config_->num_threads);
 
     // add variables
-    problem.addStateVariable(T_r_v_var);
+    problem.addStateVariable(T_s_vs_var);
 
     // add prior cost terms
     if (prior_cost_term != nullptr) problem.addCostTerm(prior_cost_term);
@@ -227,9 +227,14 @@ void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &output,
 
       // query and reference point
       const auto qry_pt = query_mat.block<2, 1>(0, ind.first).cast<double>();
-      const auto ref_pt = map_mat.block<2, 1>(0, ind.second).cast<double>();
+      const auto ref_pt_vs = T_vs_m * map_mat.block<4, 1>(0, ind.second).cast<double>();
+      const auto ref_pt = ref_pt_vs.block<2, 1>(0, 0);
+      const auto error_func = p2p::p2pSE2Error(T_vs_s_eval, ref_pt, qry_pt);
 
-      const auto error_func = p2p::p2pSE2Error(T_m_s_eval, ref_pt, qry_pt);
+      if (step == 0 && ind.first == 0) {
+        CLOG(DEBUG, "radar.localization_icp") << "First query point: " <<  query_mat.block<4, 1>(0, ind.first).transpose();
+        CLOG(DEBUG, "radar.localization_icp") << "First reference point: " << ref_pt_vs.transpose();
+      }
 
       // create cost term and add to problem
       auto cost = WeightedLeastSqCostTerm<2>::MakeShared(error_func, noise_model, loss_func);
@@ -250,18 +255,19 @@ void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &output,
     /// Alignment
     timer[4]->start();
     {
-      const auto T_m_s = T_m_s_eval->evaluate().toSE3().matrix().cast<float>();
-      aligned_mat = T_m_s * query_mat;
+      const auto T_s_m = T_s_vs_var->evaluate().toSE3() * T_vs_m;
+      const auto T_s_m_mat_f = T_s_m.inverse().matrix().cast<float>();
+      aligned_mat = T_s_m_mat_f * query_mat;
     }
 
     // Update all result matrices
-    const auto T_m_s = T_m_s_eval->evaluate().matrix();
+    const auto T_vs_s = T_vs_s_eval->evaluate().matrix();
     if (step == 0)
-      all_tfs = Eigen::MatrixXd(T_m_s);
+      all_tfs = Eigen::MatrixXd(T_vs_s);
     else {
       Eigen::MatrixXd temp(all_tfs.rows() + 3, 3);
       temp.topRows(all_tfs.rows()) = all_tfs;
-      temp.bottomRows(3) = Eigen::MatrixXd(T_m_s);
+      temp.bottomRows(3) = Eigen::MatrixXd(T_vs_s);
       all_tfs = temp;
     }
     timer[4]->stop();
@@ -312,8 +318,9 @@ void LocalizationICPModule::run_(QueryCache &qdata0, OutputCache &output,
          mean_dT < config_->trans_diff_thresh &&
          mean_dR < config_->rot_diff_thresh)) {
       // result
-      const Eigen::Matrix3d cov_var = covariance.query(T_r_v_var);
-      T_r_v_icp = EdgeTransform(T_r_v_var->value().toSE3(), cov2Dto3D(cov_var));
+      const Eigen::Matrix3d cov_var = covariance.query(T_s_vs_var);
+      T_s_vs_icp = EdgeTransform(T_s_vs_var->value().toSE3(), cov2Dto3D(cov_var));
+      T_r_v_icp = T_s_r.inverse() * T_s_vs_icp * T_s_r;
       matched_points_ratio = (float)filtered_sample_inds.size() / (float)sample_inds.size();
       //
       CLOG(DEBUG, "radar.localization_icp") << "Total number of steps: " << step << ", with matched ratio " << matched_points_ratio;

--- a/main/src/vtr_radar/src/modules/odometry/odometry_gt_module.cpp
+++ b/main/src/vtr_radar/src/modules/odometry/odometry_gt_module.cpp
@@ -120,8 +120,7 @@ void OdometryGTModule::run_(QueryCache &qdata0, OutputCache &,
     return;
   }
 
-  CLOG(DEBUG, "radar.odometry_gt")
-      << "Retrieve input data and setup evaluators.";
+  CLOG(DEBUG, "radar.odometry_gt") << "Retrieve input data and setup evaluators.";
 
   // Inputs (these are all 3D to be consistent with other pipelines)
   const auto &scan_stamp = *qdata.stamp;
@@ -136,34 +135,33 @@ void OdometryGTModule::run_(QueryCache &qdata0, OutputCache &,
   const auto &timestamp_prev = *qdata.timestamp_prior;
 
   // Compute velocity in robot frame
-  const auto Ad_T_r_s = lgmath::se2::tranAd(T_s_r.inverse().toSE2().matrix());
   const auto v_s_gt_2d = vec3Dto2D(v_s_gt);
-  const auto v_r_gt_2d = Ad_T_r_s * v_s_gt_2d;
   const auto v_s_gt_prev_2d = vec3Dto2D(v_s_gt_prev);
-  const auto v_r_gt_prev_2d = Ad_T_r_s * v_s_gt_prev_2d;
+  const auto Ad_T_r_s = lgmath::se3::tranAd(T_s_r.inverse().matrix());
+  const auto v_r_gt = Ad_T_r_s * v_s_gt;
+  const auto v_r_gt_prev = Ad_T_r_s * v_s_gt_prev;
+  const auto v_r_gt_2d = vec3Dto2D(v_r_gt);
+  const auto v_r_gt_prev_2d = vec3Dto2D(v_r_gt_prev);
 
   // Compute odometry change from groundtruth
   auto T_r_s = T_s_r.inverse();
-  auto del_T_r = (T_r_s * T_s_world_gt * T_s_world_gt_prev.inverse() * T_s_r).toSE2().toSE3();
+  auto del_T_s = (T_s_world_gt * T_s_world_gt_prev.inverse()).toSE2().toSE3(); // Enforce only SE2 change in sensor frame
+  auto del_T_r = (T_r_s *del_T_s * T_s_r);
 
   // Compute new odometry at radar scan time
   auto T_r_m_new = del_T_r * T_r_m_odo_prev;
 
   // Create trajectory for undistortion
+  // We want the trajectory to be in the sensor frame since that's the frame that is 2D
+  // These two transforms resolve the robot frame and the map frame (rooted at a specific robot pose) to the sensor frame
+  auto T_s_ms_odo_prev = (T_s_r * T_r_m_odo_prev * T_s_r.inverse()).toSE2();
+  auto T_s_ms_new = (T_s_r * T_r_m_new * T_s_r.inverse()).toSE2();
   const_vel_se2::Interface::Ptr trajectory = const_vel_se2::Interface::MakeShared(config_->traj_qc_diag);
   // Add poses and velocities to trajectory
-  trajectory->add(Time(timestamp_prev), SE2StateVar::MakeShared(T_r_m_odo_prev.toSE2()),
-                  VSpaceStateVar<3>::MakeShared(v_r_gt_prev_2d));
-  trajectory->add(Time(scan_stamp), SE2StateVar::MakeShared(T_r_m_new.toSE2()),
-                  VSpaceStateVar<3>::MakeShared(v_r_gt_2d));
-  
-  // Create robot to sensor transform variable, fixed.
-  const auto T_s_r_var = SE2StateVar::MakeShared(T_s_r.toSE2());
-  T_s_r_var->locked() = true;
-
-  // Compound transform for alignment (sensor to point map transform)
-  Evaluable<lgmath::se2::Transformation>::ConstPtr T_r_m_eval = trajectory->getPoseInterpolator(scan_stamp);
-  const auto T_m_s_eval = inverse(compose(T_s_r_var, T_r_m_eval));
+  trajectory->add(Time(timestamp_prev), SE2StateVar::MakeShared(T_s_ms_odo_prev),
+                  VSpaceStateVar<3>::MakeShared(v_s_gt_prev_2d));
+  trajectory->add(Time(scan_stamp), SE2StateVar::MakeShared(T_s_ms_new),
+                  VSpaceStateVar<3>::MakeShared(v_s_gt_2d));
 
   // Initialize aligned points for matching (Deep copy of targets)
   pcl::PointCloud<PointWithInfo> aligned_points(query_points);
@@ -185,8 +183,8 @@ void OdometryGTModule::run_(QueryCache &qdata0, OutputCache &,
     for (unsigned i = 0; i < query_points.size(); ++i) {
       const auto &qry_time = query_points[i].timestamp;
       const auto &up_chirp = query_points[i].up_chirp;
-      const auto w_m_r_in_r_intp_eval = trajectory->getVelocityInterpolator(Time(qry_time));
-      const auto w_m_s_in_s_intp_eval = compose_velocity(T_s_r_var, w_m_r_in_r_intp_eval);
+      // Velocity for this traj is already in the sensor frame
+      const auto w_m_s_in_s_intp_eval = trajectory->getVelocityInterpolator(Time(qry_time));
       const auto w_m_s_in_s = w_m_s_in_s_intp_eval->evaluate().matrix().cast<float>();
       // Still create 3D v_m_s_in_s but just with a 0 z component
       const Eigen::Vector3f v_m_s_in_s = Eigen::Vector3f(w_m_s_in_s(0), w_m_s_in_s(1), 0.0f);
@@ -200,21 +198,19 @@ void OdometryGTModule::run_(QueryCache &qdata0, OutputCache &,
       }
     }
   }
+
+  // Transform each point to the sensor frame at the query timestamp using the trajectory
+  // This undistorts the point cloud to the query timestamp
+  const auto T_squery_ms = trajectory->getPoseInterpolator(Time(scan_stamp));
 #pragma omp parallel for schedule(dynamic, 10) num_threads(config_->num_threads)
   for (unsigned i = 0; i < query_points.size(); i++) {
     const auto &qry_time = query_points[i].timestamp;
-    const auto T_r_m_intp_eval = trajectory->getPoseInterpolator(Time(qry_time));
-    const auto T_m_s_intp_eval = inverse(compose(T_s_r_var, T_r_m_intp_eval));
+    const auto T_s_ms_intp_eval = trajectory->getPoseInterpolator(Time(qry_time));
     // Transform to 3D for point manipulation
-    const auto T_m_s = T_m_s_intp_eval->evaluate().toSE3().matrix().cast<float>();
-    aligned_mat.block<4, 1>(0, i) = T_m_s * aligned_mat.block<4, 1>(0, i);
-    aligned_norms_mat.block<4, 1>(0, i) = T_m_s * query_norms_mat.block<4, 1>(0, i);
+    const auto T_squery_s = compose(T_squery_ms, inverse(T_s_ms_intp_eval))->evaluate().toSE3().matrix().cast<float>();
+    aligned_mat.block<4, 1>(0, i) = T_squery_s * aligned_mat.block<4, 1>(0, i);
+    aligned_norms_mat.block<4, 1>(0, i) = T_squery_s * query_norms_mat.block<4, 1>(0, i);
   }
-
-  // undistort the preprocessed pointcloud to eval state (at query timestamp)
-  const auto T_s_m = T_m_s_eval->evaluate().toSE3().matrix().inverse().cast<float>();
-  aligned_mat = T_s_m * aligned_mat;
-  aligned_norms_mat = T_s_m * aligned_norms_mat;
 
   auto undistorted_point_cloud = std::make_shared<pcl::PointCloud<PointWithInfo>>(aligned_points);
   cart2pol(*undistorted_point_cloud);  // correct polar coordinates.

--- a/main/src/vtr_radar/src/modules/odometry/odometry_gt_module.cpp
+++ b/main/src/vtr_radar/src/modules/odometry/odometry_gt_module.cpp
@@ -139,9 +139,7 @@ void OdometryGTModule::run_(QueryCache &qdata0, OutputCache &,
   const auto v_s_gt_prev_2d = vec3Dto2D(v_s_gt_prev);
   const auto Ad_T_r_s = lgmath::se3::tranAd(T_s_r.inverse().matrix());
   const auto v_r_gt = Ad_T_r_s * v_s_gt;
-  const auto v_r_gt_prev = Ad_T_r_s * v_s_gt_prev;
   const auto v_r_gt_2d = vec3Dto2D(v_r_gt);
-  const auto v_r_gt_prev_2d = vec3Dto2D(v_r_gt_prev);
 
   // Compute odometry change from groundtruth
   auto T_r_s = T_s_r.inverse();

--- a/main/src/vtr_radar/src/modules/odometry/odometry_icp_module.cpp
+++ b/main/src/vtr_radar/src/modules/odometry/odometry_icp_module.cpp
@@ -297,10 +297,8 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
   /// create kd-tree of the map
   // Transform point map (currently in map frame m) into map sensor frame (ms) for matching.
   const auto T_s_r_mat_f = T_s_r.matrix().cast<float>();
-  for (unsigned i = 0; i < point_map_copy.size(); ++i) {
-    map_mat.block<4, 1>(0, i) = T_s_r_mat_f * map_mat.block<4, 1>(0, i);
-    map_normals_mat.block<4, 1>(0, i) = T_s_r_mat_f * map_normals_mat.block<4, 1>(0, i);
-  }
+  map_mat = T_s_r_mat_f * map_mat;
+  map_normals_mat = T_s_r_mat_f * map_normals_mat;
 
   CLOG(DEBUG, "radar.odometry_icp") << "Start building a kd-tree of the map.";
   NanoFLANNAdapter<PointWithInfo> adapter(point_map_copy);

--- a/main/src/vtr_radar/src/modules/odometry/odometry_icp_module.cpp
+++ b/main/src/vtr_radar/src/modules/odometry/odometry_icp_module.cpp
@@ -234,10 +234,6 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
 
   // clang-format off
   /// trajectory smoothing (these are 2D since we want to optimize in 2D)
-  Evaluable<lgmath::se2::Transformation>::ConstPtr T_r_m_eval = nullptr;
-  Evaluable<Eigen::Matrix<double, 3, 1>>::ConstPtr w_m_r_in_r_eval = nullptr;
-  Evaluable<lgmath::se2::Transformation>::ConstPtr T_r_m_eval_extp = nullptr;
-  Evaluable<Eigen::Matrix<double, 3, 1>>::ConstPtr w_m_r_in_r_eval_extp = nullptr;
   lgmath::se2::Transformation T_s_ms_odo_prior_new;
   Eigen::Matrix<double, 3, 1> w_ms_s_in_s_odo_prior_new;
   Eigen::Matrix<double, 6, 6> cov_prior_new;
@@ -268,15 +264,11 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
   trajectory->addStatePrior(Time(frame_start_time), T_s_ms_odo_prior_2d, w_ms_s_in_s_odo_prior_2d, cov_prior_2d);
 
   // General radar odometry (at scan time)
-  T_r_m_eval = trajectory->getPoseInterpolator(scan_time);
-  w_m_r_in_r_eval = trajectory->getVelocityInterpolator(scan_time);
   T_s_ms_eval = trajectory->getPoseInterpolator(scan_time);
   w_ms_s_in_s_eval = trajectory->getVelocityInterpolator(scan_time);
 
   // Odometry at extrapolated state (might be the same as above, but not necessarily, if we have gyro)
   Time extp_time(static_cast<int64_t>(timestamp_odo_new));
-  T_r_m_eval_extp = trajectory->getPoseInterpolator(extp_time);
-  w_m_r_in_r_eval_extp = trajectory->getVelocityInterpolator(extp_time);
   T_s_ms_eval_extp = trajectory->getPoseInterpolator(extp_time);
   w_ms_s_in_s_eval_extp = trajectory->getVelocityInterpolator(extp_time);
 

--- a/main/src/vtr_radar/src/modules/odometry/odometry_icp_module.cpp
+++ b/main/src/vtr_radar/src/modules/odometry/odometry_icp_module.cpp
@@ -275,23 +275,19 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
   /// Initialize aligned points for matching (Deep copy of targets)
   pcl::PointCloud<PointWithInfo> aligned_points(query_points);
 
+  /// Eigen matrix of original data (only shallow copy of ref clouds)
+  const auto query_mat = query_points.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::cartesian_offset());
+  auto aligned_mat = aligned_points.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::cartesian_offset());
+
   /// Deep copy of map points (since we will be transforming them for matching)
   pcl::PointCloud<PointWithInfo> point_map_copy(point_map);
   auto map_mat = point_map_copy.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::cartesian_offset());
-  auto map_normals_mat = point_map_copy.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::normal_offset());
 
-  /// Eigen matrix of original data (only shallow copy of ref clouds)
-  const auto query_mat = query_points.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::cartesian_offset());
-  const auto query_norms_mat = query_points.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::normal_offset());
-  auto aligned_mat = aligned_points.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::cartesian_offset());
-  auto aligned_norms_mat = aligned_points.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::normal_offset());
-
-  /// create kd-tree of the map
   // Transform point map (currently in map frame m) into map sensor frame (ms) for matching.
   const auto T_s_r_mat_f = T_s_r.matrix().cast<float>();
   map_mat = T_s_r_mat_f * map_mat;
-  map_normals_mat = T_s_r_mat_f * map_normals_mat;
 
+  /// create kd-tree of the map
   CLOG(DEBUG, "radar.odometry_icp") << "Start building a kd-tree of the map.";
   NanoFLANNAdapter<PointWithInfo> adapter(point_map_copy);
   KDTreeParams tree_params(10 /* max leaf */);
@@ -333,7 +329,6 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
     // Transform to 3D for point manipulation
     const auto T_ms_s = T_ms_s_intp_eval->evaluate().toSE3().matrix().cast<float>();
     aligned_mat.block<4, 1>(0, i) = T_ms_s * aligned_mat.block<4, 1>(0, i);
-    aligned_norms_mat.block<4, 1>(0, i) = T_ms_s * query_norms_mat.block<4, 1>(0, i);
   }
   // aligned_mat is now motion/Doppler undistorted and in the same ms frame
   // map_mat is now in ms frame as well
@@ -607,7 +602,6 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
       // Transform to 3D for point manipulation
       const auto T_ms_s = T_ms_s_intp_eval->evaluate().toSE3().matrix().cast<float>();
       aligned_mat.block<4, 1>(0, i) = T_ms_s * aligned_mat.block<4, 1>(0, i);
-      aligned_norms_mat.block<4, 1>(0, i) = T_ms_s * query_norms_mat.block<4, 1>(0, i);
     }
     // aligned_mat is now in ms frame using latest estimate
 
@@ -748,7 +742,6 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
     // undistort the preprocessed pointcloud to eval state (at query timestamp)
     const auto T_s_ms = T_s_ms_eval->evaluate().toSE3().matrix().cast<float>();
     aligned_mat = T_s_ms * aligned_mat;
-    aligned_norms_mat = T_s_ms * aligned_norms_mat;
 
     auto undistorted_point_cloud = std::make_shared<pcl::PointCloud<PointWithInfo>>(aligned_points);
     cart2pol(*undistorted_point_cloud);  // correct polar coordinates.

--- a/main/src/vtr_radar/src/modules/odometry/odometry_icp_module.cpp
+++ b/main/src/vtr_radar/src/modules/odometry/odometry_icp_module.cpp
@@ -180,12 +180,25 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
   auto &sliding_map_odo = *qdata.sliding_map_odo;
   auto &point_map = sliding_map_odo.point_cloud();
 
-  // Extract 2D transforms
-  const lgmath::se2::Transformation T_s_r_2d = T_s_r.toSE2();
-  const lgmath::se2::Transformation T_r_m_odo_2d = T_r_m_odo.toSE2();
-  const Eigen::Matrix<double, 3, 1> w_m_r_in_r_odo_2d = vec3Dto2D(w_m_r_in_r_odo);
-  const lgmath::se2::Transformation T_r_m_odo_prior_2d = T_r_m_odo_prior.toSE2();
-  const Eigen::Matrix<double, 3, 1> w_m_r_in_r_odo_prior_2d = vec3Dto2D(w_m_r_in_r_odo_prior);
+  // We want to do ICP within the sensor frame to keep it 2D
+  // This means that we want the map transformed into the sensor frame (ms)
+  // and the estimation frame to be the sensor frame (s)
+  const_vel_se2::Interface::Ptr trajectory = const_vel_se2::Interface::MakeShared(config_->traj_qc_diag);
+  Evaluable<lgmath::se2::Transformation>::ConstPtr T_s_ms_eval = nullptr;
+  Evaluable<Eigen::Matrix<double, 3, 1>>::ConstPtr w_ms_s_in_s_eval = nullptr;
+  Evaluable<lgmath::se2::Transformation>::ConstPtr T_s_ms_eval_extp = nullptr;
+  Evaluable<Eigen::Matrix<double, 3, 1>>::ConstPtr w_ms_s_in_s_eval_extp = nullptr;
+
+  // Initialize common transforms
+  const auto T_r_s = T_s_r.inverse();
+  const auto Ad_T_r_s = lgmath::se3::tranAd(T_r_s.matrix());
+  const auto Ad_T_s_r = lgmath::se3::tranAd(T_s_r.matrix());
+  const auto T_s_ms_odo_prior = T_s_r * T_r_m_odo_prior * T_r_s;
+  const auto T_s_ms_odo_prior_2d = T_s_ms_odo_prior.toSE2();
+  const Eigen::Matrix<double, 6, 1> w_m_s_in_s_odo_prior = Ad_T_s_r * w_m_r_in_r_odo_prior;
+  const Eigen::Matrix<double, 3, 1> w_ms_s_in_s_odo_prior_2d = vec3Dto2D(w_m_s_in_s_odo_prior);
+
+  // cov_prior is in T_s_ms frame already for simplicity
   const Eigen::Matrix<double, 6, 6> cov_prior_2d = cov3Dto2D(cov_prior);
 
   // Parameters
@@ -225,9 +238,8 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
   Evaluable<Eigen::Matrix<double, 3, 1>>::ConstPtr w_m_r_in_r_eval = nullptr;
   Evaluable<lgmath::se2::Transformation>::ConstPtr T_r_m_eval_extp = nullptr;
   Evaluable<Eigen::Matrix<double, 3, 1>>::ConstPtr w_m_r_in_r_eval_extp = nullptr;
-  const_vel_se2::Interface::Ptr trajectory = const_vel_se2::Interface::MakeShared(config_->traj_qc_diag);
-  lgmath::se2::Transformation T_r_m_odo_prior_new;
-  Eigen::Matrix<double, 3, 1> w_m_r_in_r_odo_prior_new;
+  lgmath::se2::Transformation T_s_ms_odo_prior_new;
+  Eigen::Matrix<double, 3, 1> w_ms_s_in_s_odo_prior_new;
   Eigen::Matrix<double, 6, 6> cov_prior_new;
   std::vector<StateVarBase::Ptr> state_vars;
 
@@ -239,55 +251,66 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
     const int64_t knot_time_stamp = (i == num_states - 1) ? frame_end_time : frame_start_time + i * time_diff;
     Time knot_time(static_cast<int64_t>(knot_time_stamp));
     const Eigen::Matrix<double, 6, 1> xi_m_r_in_r_odo((knot_time - timestamp_prior).seconds() * w_m_r_in_r_odo_prior);
-    const auto T_r_m_odo_extp = (tactic::EdgeTransform(xi_m_r_in_r_odo) * T_r_m_odo_prior).toSE2();
-    const std::string T_r_m_var_name = "T_r_m_" + std::to_string(i);
-    const auto T_r_m_var = SE2StateVar::MakeShared(T_r_m_odo_extp, T_r_m_var_name);
-    const std::string w_m_r_in_r_var_name = "w_m_r_in_r_" + std::to_string(i);
-    const auto w_m_r_in_r_var = VSpaceStateVar<3>::MakeShared(w_m_r_in_r_odo_prior_2d, w_m_r_in_r_var_name);
-    trajectory->add(knot_time, T_r_m_var, w_m_r_in_r_var);
-    state_vars.emplace_back(T_r_m_var);
-    state_vars.emplace_back(w_m_r_in_r_var);
+    const auto T_r_m_odo_extp = tactic::EdgeTransform(xi_m_r_in_r_odo) * T_r_m_odo_prior;
+    const auto T_s_ms_odo_extp = T_s_r * T_r_m_odo_extp * T_r_s;
+    const auto T_s_ms_odo_extp_2d = T_s_ms_odo_extp.toSE2();
+    const std::string T_s_ms_var_name = "T_s_ms_" + std::to_string(i);
+    const auto T_s_ms_var = SE2StateVar::MakeShared(T_s_ms_odo_extp_2d, T_s_ms_var_name);
+    const std::string w_ms_s_in_s_var_name = "w_ms_s_in_s_" + std::to_string(i);
+    const auto w_ms_s_in_s_var = VSpaceStateVar<3>::MakeShared(w_ms_s_in_s_odo_prior_2d, w_ms_s_in_s_var_name);
+    trajectory->add(knot_time, T_s_ms_var, w_ms_s_in_s_var);
+    state_vars.emplace_back(T_s_ms_var);
+    state_vars.emplace_back(w_ms_s_in_s_var);
   }
 
   // Set up priors
   CLOG(DEBUG, "radar.odometry_icp") << "Adding prior to trajectory.";
-  trajectory->addStatePrior(Time(frame_start_time), T_r_m_odo_prior_2d, w_m_r_in_r_odo_prior_2d, cov_prior_2d);
+  trajectory->addStatePrior(Time(frame_start_time), T_s_ms_odo_prior_2d, w_ms_s_in_s_odo_prior_2d, cov_prior_2d);
 
   // General radar odometry (at scan time)
   T_r_m_eval = trajectory->getPoseInterpolator(scan_time);
   w_m_r_in_r_eval = trajectory->getVelocityInterpolator(scan_time);
+  T_s_ms_eval = trajectory->getPoseInterpolator(scan_time);
+  w_ms_s_in_s_eval = trajectory->getVelocityInterpolator(scan_time);
 
   // Odometry at extrapolated state (might be the same as above, but not necessarily, if we have gyro)
   Time extp_time(static_cast<int64_t>(timestamp_odo_new));
   T_r_m_eval_extp = trajectory->getPoseInterpolator(extp_time);
   w_m_r_in_r_eval_extp = trajectory->getVelocityInterpolator(extp_time);
-
-  /// Create robot to sensor transform variable, fixed.
-  const auto T_s_r_var = SE2StateVar::MakeShared(T_s_r_2d);
-  T_s_r_var->locked() = true;
-  /// compound transform for alignment (sensor to point map transform)
-  const auto T_m_s_eval = inverse(compose(T_s_r_var, T_r_m_eval));
+  T_s_ms_eval_extp = trajectory->getPoseInterpolator(extp_time);
+  w_ms_s_in_s_eval_extp = trajectory->getVelocityInterpolator(extp_time);
 
   /// Initialize aligned points for matching (Deep copy of targets)
   pcl::PointCloud<PointWithInfo> aligned_points(query_points);
 
+  /// Deep copy of map points (since we will be transforming them for matching)
+  pcl::PointCloud<PointWithInfo> point_map_copy(point_map);
+  auto map_mat = point_map_copy.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::cartesian_offset());
+  auto map_normals_mat = point_map_copy.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::normal_offset());
+
   /// Eigen matrix of original data (only shallow copy of ref clouds)
-  const auto map_mat = point_map.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::cartesian_offset());
-  const auto map_normals_mat = point_map.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::normal_offset());
   const auto query_mat = query_points.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::cartesian_offset());
   const auto query_norms_mat = query_points.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::normal_offset());
   auto aligned_mat = aligned_points.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::cartesian_offset());
   auto aligned_norms_mat = aligned_points.getMatrixXfMap(4, PointWithInfo::size(), PointWithInfo::normal_offset());
 
   /// create kd-tree of the map
+  // Transform point map (currently in map frame m) into map sensor frame (ms) for matching.
+  const auto T_s_r_mat_f = T_s_r.matrix().cast<float>();
+  for (unsigned i = 0; i < point_map_copy.size(); ++i) {
+    map_mat.block<4, 1>(0, i) = T_s_r_mat_f * map_mat.block<4, 1>(0, i);
+    map_normals_mat.block<4, 1>(0, i) = T_s_r_mat_f * map_normals_mat.block<4, 1>(0, i);
+  }
+
   CLOG(DEBUG, "radar.odometry_icp") << "Start building a kd-tree of the map.";
-  NanoFLANNAdapter<PointWithInfo> adapter(point_map);
+  NanoFLANNAdapter<PointWithInfo> adapter(point_map_copy);
   KDTreeParams tree_params(10 /* max leaf */);
   auto kdtree = std::make_unique<KDTree<PointWithInfo>>(3, adapter, tree_params);
   kdtree->buildIndex();
 
   /// perform initial alignment
   CLOG(DEBUG, "radar.odometry_icp") << "Start initial alignment.";
+  // First, do Doppler undistortion
 #pragma omp parallel for schedule(dynamic, 10) num_threads(config_->num_threads)
   for (unsigned i = 0; i < query_points.size(); ++i) {
     aligned_mat.block<4, 1>(0, i) = query_mat.block<4, 1>(0, i);
@@ -297,31 +320,34 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
     for (unsigned i = 0; i < query_points.size(); ++i) {
       const auto &qry_time = query_points[i].timestamp;
       const auto &up_chirp = query_points[i].up_chirp;
-      const auto w_m_r_in_r_intp_eval = trajectory->getVelocityInterpolator(Time(qry_time));
-      const auto w_m_s_in_s_intp_eval = compose_velocity(T_s_r_var, w_m_r_in_r_intp_eval);
-      const auto w_m_s_in_s = w_m_s_in_s_intp_eval->evaluate().matrix().cast<float>();
-      // Still create 3D v_m_s_in_s but just with a 0 z component
-      const Eigen::Vector3f v_m_s_in_s = Eigen::Vector3f(w_m_s_in_s(0), w_m_s_in_s(1), 0.0f);
+      const auto w_ms_s_in_s_intp_eval = trajectory->getVelocityInterpolator(Time(qry_time));
+      const auto w_ms_s_in_s = w_ms_s_in_s_intp_eval->evaluate().matrix().cast<float>();
+      // Still create 3D v_ms_s_in_s but just with a 0 z component
+      const Eigen::Vector3f v_ms_s_in_s = Eigen::Vector3f(w_ms_s_in_s(0), w_ms_s_in_s(1), 0.0f);
       Eigen::Vector3f abar = aligned_mat.block<3, 1>(0, i);
       abar.normalize();
       // If up chirp azimuth, subtract Doppler shift
       if (up_chirp) { 
-        aligned_mat.block<3, 1>(0, i) -= beta * abar * abar.transpose() * v_m_s_in_s;
+        aligned_mat.block<3, 1>(0, i) -= beta * abar * abar.transpose() * v_ms_s_in_s;
       } else {
-        aligned_mat.block<3, 1>(0, i) += beta * abar * abar.transpose() * v_m_s_in_s;
+        aligned_mat.block<3, 1>(0, i) += beta * abar * abar.transpose() * v_ms_s_in_s;
       }
     }
   }
+  // Next, transform all points to the same ms frame
 #pragma omp parallel for schedule(dynamic, 10) num_threads(config_->num_threads)
   for (unsigned i = 0; i < query_points.size(); i++) {
     const auto &qry_time = query_points[i].timestamp;
-    const auto T_r_m_intp_eval = trajectory->getPoseInterpolator(Time(qry_time));
-    const auto T_m_s_intp_eval = inverse(compose(T_s_r_var, T_r_m_intp_eval));
+    const auto T_s_ms_intp_eval = trajectory->getPoseInterpolator(Time(qry_time));
+    const auto T_ms_s_intp_eval = inverse(T_s_ms_intp_eval);
     // Transform to 3D for point manipulation
-    const auto T_m_s = T_m_s_intp_eval->evaluate().toSE3().matrix().cast<float>();
-    aligned_mat.block<4, 1>(0, i) = T_m_s * aligned_mat.block<4, 1>(0, i);
-    aligned_norms_mat.block<4, 1>(0, i) = T_m_s * query_norms_mat.block<4, 1>(0, i);
+    const auto T_ms_s = T_ms_s_intp_eval->evaluate().toSE3().matrix().cast<float>();
+    aligned_mat.block<4, 1>(0, i) = T_ms_s * aligned_mat.block<4, 1>(0, i);
+    aligned_norms_mat.block<4, 1>(0, i) = T_ms_s * query_norms_mat.block<4, 1>(0, i);
   }
+  // aligned_mat is now motion/Doppler undistorted and in the same ms frame
+  // map_mat is now in ms frame as well
+  // query_mat is in sensor frame
 
   using Stopwatch = common::timing::Stopwatch<>;
   std::vector<std::unique_ptr<Stopwatch>> timer;
@@ -343,6 +369,7 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
 
   // ICP results
   EdgeTransform T_r_m_icp;
+  EdgeTransform T_s_ms_icp;
   float matched_points_ratio = 0.0;
 
   // Convergence variables
@@ -418,20 +445,19 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
 
       auto icp_error_func = [&]() -> Evaluable<Eigen::Matrix<double, 2, 1>>::Ptr {
         const auto &qry_time = query_points[ind.first].timestamp;
-        const auto T_r_m_intp_eval = trajectory->getPoseInterpolator(Time(qry_time));
-        const auto T_m_s_intp_eval = inverse(compose(T_s_r_var, T_r_m_intp_eval));
+        const auto T_s_ms_intp_eval = trajectory->getPoseInterpolator(Time(qry_time));
+        const auto T_ms_s_intp_eval = inverse(T_s_ms_intp_eval);
         if (beta != 0) {
-          const auto w_m_r_in_r_intp_eval = trajectory->getVelocityInterpolator(Time(qry_time));
-          const auto w_m_s_in_s_intp_eval = compose_velocity(T_s_r_var, w_m_r_in_r_intp_eval);
+          const auto w_ms_s_in_s_intp_eval = trajectory->getVelocityInterpolator(Time(qry_time));
           const auto &up_chirp = query_points[ind.first].up_chirp;
           if (up_chirp) {
-            return p2p::p2pSE2ErrorDoppler(T_m_s_intp_eval, w_m_s_in_s_intp_eval, ref_pt, qry_pt, beta, rm_ori);
+            return p2p::p2pSE2ErrorDoppler(T_ms_s_intp_eval, w_ms_s_in_s_intp_eval, ref_pt, qry_pt, beta, rm_ori);
           } else {
-            return p2p::p2pSE2ErrorDoppler(T_m_s_intp_eval, w_m_s_in_s_intp_eval, ref_pt, qry_pt, -beta, rm_ori);
+            return p2p::p2pSE2ErrorDoppler(T_ms_s_intp_eval, w_ms_s_in_s_intp_eval, ref_pt, qry_pt, -beta, rm_ori);
           }
           
         } else {
-          return p2p::p2pSE2Error(T_m_s_intp_eval, ref_pt, qry_pt, rm_ori);
+          return p2p::p2pSE2Error(T_ms_s_intp_eval, ref_pt, qry_pt, rm_ori);
         }
       }();
 
@@ -457,8 +483,7 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
         const Eigen::Matrix<double, 1, 1> radial_velocity_vec = radial_velocity * Eigen::Matrix<double, 1, 1>::Ones();
 
         // Get velocity in radar frame
-        const auto w_m_r_in_r_intp_eval = trajectory->getVelocityInterpolator(Time(dopp_time));
-        const auto w_m_s_in_s_intp_eval = compose_velocity(T_s_r_var, w_m_r_in_r_intp_eval);
+        const auto w_ms_s_in_s_intp_eval = trajectory->getVelocityInterpolator(Time(dopp_time));
 
         // Generate empty bias state (for now)
         Eigen::Matrix<double, 3, 1> b_zero = Eigen::Matrix<double, 3, 1>::Zero();
@@ -469,7 +494,7 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
         // Form error terms
         const auto loss_func = CauchyLossFunc::MakeShared(config_->dopp_cauchy_k);
         const auto noise_model = StaticNoiseModel<1>::MakeShared(Eigen::Matrix<double, 1, 1>(config_->dopp_meas_std));
-        const auto error_func = se2::RadialVelErrorEvaluator::MakeShared(w_m_s_in_s_intp_eval, bias, azimuth, radial_velocity_vec);
+        const auto error_func = se2::RadialVelErrorEvaluator::MakeShared(w_ms_s_in_s_intp_eval, bias, azimuth, radial_velocity_vec);
         const auto doppler_cost = WeightedLeastSqCostTerm<1>::MakeShared(error_func, noise_model, loss_func, "doppler_cost" + std::to_string(azimuth_idx));
 
         // Add cost term to problem
@@ -492,14 +517,14 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
         const rclcpp::Time gyro_stamp(gyro_msg.header.stamp);
         const auto gyro_stamp_time = static_cast<int64_t>(gyro_stamp.nanoseconds());
 
-        // Transform gyro measurement into robot frame
+        // Transform gyro measurement into sensor (radar) frame
         Eigen::VectorXd gyro_meas_g(3);
         gyro_meas_g << 0, 0, yaw_meas;
-        const Eigen::Matrix<double, 3, 1> gyro_meas_r =  T_s_r_gyro.matrix().block<3, 3>(0, 0).transpose() * gyro_meas_g;
-        const double yaw_meas_r = gyro_meas_r(2);
+        const Eigen::Matrix<double, 3, 1> gyro_meas_s = T_s_r.matrix().block<3, 3>(0, 0) * T_s_r_gyro.matrix().block<3, 3>(0, 0).transpose() * gyro_meas_g;
+        const double yaw_meas_s = gyro_meas_s(2);
 
         // Interpolate velocity measurement at gyro stamp
-        auto w_m_r_in_r_intp_eval = trajectory->getVelocityInterpolator(Time(gyro_stamp_time));
+        auto w_ms_s_in_s_intp_eval = trajectory->getVelocityInterpolator(Time(gyro_stamp_time));
 
         // Generate empty bias state
         Eigen::Matrix<double, 3, 1> b_zero = Eigen::Matrix<double, 3, 1>::Zero();
@@ -508,7 +533,7 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
         const auto loss_func = L2LossFunc::MakeShared();
         Eigen::Matrix<double, 1, 1> W_gyro = config_->gyro_cov * Eigen::Matrix<double, 1, 1>::Identity();
         const auto noise_model = StaticNoiseModel<1>::MakeShared(W_gyro);
-        const auto error_func = imu::GyroErrorEvaluatorSE2::MakeShared(w_m_r_in_r_intp_eval, bias, yaw_meas_r);
+        const auto error_func = imu::GyroErrorEvaluatorSE2::MakeShared(w_ms_s_in_s_intp_eval, bias, yaw_meas_s);
         const auto gyro_cost = WeightedLeastSqCostTerm<1>::MakeShared(error_func, noise_model, loss_func, "gyro_cost" + std::to_string(gyro_stamp_time));
 
 #pragma omp critical(odo_icp_add_gyro_error_cost)
@@ -526,8 +551,7 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
 
       const auto &vel_meas = *qdata.vel_meas;
       // Get velocity measurements in sensor frame
-      const auto w_m_r_in_r_intp_eval = trajectory->getVelocityInterpolator(scan_time);
-      const auto w_m_s_in_s_intp_eval = compose_velocity(T_s_r_var, w_m_r_in_r_intp_eval);
+      const auto w_ms_s_in_s_intp_eval = trajectory->getVelocityInterpolator(scan_time);
 
       CLOG(DEBUG, "radar.odometry_icp") << "Adding velocity measurement to optimization with vel_meas: " << vel_meas.transpose();
 
@@ -537,7 +561,7 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
       const auto vel_noise_model = StaticNoiseModel<2>::MakeShared(W_vel);
       const auto vel_loss_func = CauchyLossFunc::MakeShared(config_->dopp_cauchy_k);
       // Minus sign because vel_meas is v_s_m_in_s, but we want v_m_s_in_s
-      const auto vel_err_func = se2::LinearVelErrorEvaluator::MakeShared(-vel_meas, w_m_s_in_s_intp_eval);
+      const auto vel_err_func = se2::LinearVelErrorEvaluator::MakeShared(-vel_meas, w_ms_s_in_s_intp_eval);
 
       const auto vel_cost = WeightedLeastSqCostTerm<2>::MakeShared(vel_err_func, vel_noise_model, vel_loss_func, "vel_cost");
       problem.addCostTerm(vel_cost);
@@ -571,40 +595,40 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
       for (unsigned i = 0; i < query_points.size(); ++i) {
         const auto &qry_time = query_points[i].timestamp;
         const auto &up_chirp = query_points[i].up_chirp;
-        const auto w_m_r_in_r_intp_eval = trajectory->getVelocityInterpolator(Time(qry_time));
-        const auto w_m_s_in_s_intp_eval = compose_velocity(T_s_r_var, w_m_r_in_r_intp_eval);
-        const auto w_m_s_in_s = w_m_s_in_s_intp_eval->evaluate().matrix().cast<float>();
-        // Still create 3D v_m_s_in_s but just with a 0 z component
-        const Eigen::Vector3f v_m_s_in_s = Eigen::Vector3f(w_m_s_in_s(0), w_m_s_in_s(1), 0.0f);
+        const auto w_ms_s_in_s_intp_eval = trajectory->getVelocityInterpolator(Time(qry_time));
+        const auto w_ms_s_in_s = w_ms_s_in_s_intp_eval->evaluate().matrix().cast<float>();
+        // Still create 3D v_ms_s_in_s but just with a 0 z component
+        const Eigen::Vector3f v_ms_s_in_s = Eigen::Vector3f(w_ms_s_in_s(0), w_ms_s_in_s(1), 0.0f);
         Eigen::Vector3f abar = aligned_mat.block<3, 1>(0, i);
         abar.normalize();
         if (up_chirp) {
-          aligned_mat.block<3, 1>(0, i) -= beta * abar * abar.transpose() * v_m_s_in_s;
+          aligned_mat.block<3, 1>(0, i) -= beta * abar * abar.transpose() * v_ms_s_in_s;
         } else {
-          aligned_mat.block<3, 1>(0, i) += beta * abar * abar.transpose() * v_m_s_in_s;
+          aligned_mat.block<3, 1>(0, i) += beta * abar * abar.transpose() * v_ms_s_in_s;
         }
       }
     }
 #pragma omp parallel for schedule(dynamic, 10) num_threads(config_->num_threads)
     for (unsigned i = 0; i < query_points.size(); i++) {
       const auto &qry_time = query_points[i].timestamp;
-      const auto T_r_m_intp_eval = trajectory->getPoseInterpolator(Time(qry_time));
-      const auto T_m_s_intp_eval = inverse(compose(T_s_r_var, T_r_m_intp_eval));
+      const auto T_s_ms_intp_eval = trajectory->getPoseInterpolator(Time(qry_time));
+      const auto T_ms_s_intp_eval = inverse(T_s_ms_intp_eval);
 
       // Transform to 3D for point manipulation
-      const auto T_m_s = T_m_s_intp_eval->evaluate().toSE3().matrix().cast<float>();
-      aligned_mat.block<4, 1>(0, i) = T_m_s * aligned_mat.block<4, 1>(0, i);
-      aligned_norms_mat.block<4, 1>(0, i) = T_m_s * query_norms_mat.block<4, 1>(0, i);
+      const auto T_ms_s = T_ms_s_intp_eval->evaluate().toSE3().matrix().cast<float>();
+      aligned_mat.block<4, 1>(0, i) = T_ms_s * aligned_mat.block<4, 1>(0, i);
+      aligned_norms_mat.block<4, 1>(0, i) = T_ms_s * query_norms_mat.block<4, 1>(0, i);
     }
+    // aligned_mat is now in ms frame using latest estimate
 
     // Update all result matrices
-    const auto T_m_s = T_m_s_eval->evaluate().matrix();
+    const auto T_ms_s = T_s_ms_eval->evaluate().matrix().inverse();
     if (step == 0)
-      all_tfs = Eigen::MatrixXd(T_m_s);
+      all_tfs = Eigen::MatrixXd(T_ms_s);
     else {
       Eigen::MatrixXd temp(all_tfs.rows() + 3, 3);
       temp.topRows(all_tfs.rows()) = all_tfs;
-      temp.bottomRows(3) = Eigen::MatrixXd(T_m_s);
+      temp.bottomRows(3) = Eigen::MatrixXd(T_ms_s);
       all_tfs = temp;
     }
     timer[4]->stop();
@@ -656,11 +680,13 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
          mean_dR < config_->rot_diff_thresh) || 
          solver_failed) {
       // result
-      Eigen::Matrix<double, 3, 3> T_r_m_cov = Eigen::Matrix<double, 3, 3>::Identity();
-      T_r_m_cov = trajectory->getCovariance(covariance, Time(static_cast<int64_t>(timestamp_odo_new))).block<3, 3>(0, 0);
+      Eigen::Matrix<double, 3, 3> T_s_ms_cov = Eigen::Matrix<double, 3, 3>::Identity();
+      T_s_ms_cov = trajectory->getCovariance(covariance, Time(static_cast<int64_t>(timestamp_odo_new))).block<3, 3>(0, 0);
       // Save 3D edge transform result
-      Eigen::Matrix<double, 6, 6> T_r_m_cov_3d = cov2Dto3D(T_r_m_cov);
-      T_r_m_icp = EdgeTransform(T_r_m_eval_extp->value().toSE3(), T_r_m_cov_3d);
+      Eigen::Matrix<double, 6, 6> T_s_ms_cov_3d = cov2Dto3D(T_s_ms_cov);
+      T_s_ms_icp = EdgeTransform(T_s_ms_eval_extp->value().toSE3(), T_s_ms_cov_3d);
+      // Transform result to robot frame
+      T_r_m_icp = T_r_s * T_s_ms_icp * T_s_r;
 
       // Marginalize out all but last 2 states for prior
       std::vector<StateVarBase::Ptr> state_vars_marg;
@@ -672,8 +698,8 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
       GaussNewtonSolver solver_marg(problem, params);
       solver_marg.optimize();
       Covariance covariance_marg(solver_marg);
-      T_r_m_odo_prior_new =  trajectory->get(Time(static_cast<int64_t>(frame_end_time)))->pose()->evaluate();
-      w_m_r_in_r_odo_prior_new = trajectory->get(Time(static_cast<int64_t>(frame_end_time)))->velocity()->evaluate();
+      T_s_ms_odo_prior_new =  trajectory->get(Time(static_cast<int64_t>(frame_end_time)))->pose()->evaluate();
+      w_ms_s_in_s_odo_prior_new = trajectory->get(Time(static_cast<int64_t>(frame_end_time)))->velocity()->evaluate();
       cov_prior_new = trajectory->getCovariance(covariance_marg, Time(static_cast<int64_t>(frame_end_time))).block<6, 6>(0, 0);
       cov_prior_new = 0.5 * (cov_prior_new + cov_prior_new.transpose());
 
@@ -702,20 +728,15 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
   // Outputs
   bool estimate_reasonable = true;
   // Check if change between initial and final velocity is reasonable
-  const auto &w_m_r_in_r_eval_ = trajectory->getVelocityInterpolator(Time(static_cast<int64_t>(scan_stamp)))->evaluate().matrix();
-  const auto vel_diff = w_m_r_in_r_eval_ - w_m_r_in_r_odo_2d;
+  const auto vel_diff = w_ms_s_in_s_odo_prior_new - w_ms_s_in_s_odo_prior_2d;
   const auto vel_diff_norm = vel_diff.norm();
   const auto trans_vel_diff_norm = vel_diff.head<2>().norm();
   const auto rot_vel_diff_norm = fabs(vel_diff(2));;
 
-  const auto T_r_m_prev = T_r_m_odo_2d;
-  const auto T_r_m_query = T_r_m_eval->value();
-  const auto diff_T = (T_r_m_prev * T_r_m_query.inverse()).vec();
+  const auto diff_T = (T_s_ms_odo_prior_2d * T_s_ms_odo_prior_new.inverse()).vec();
   const auto diff_T_trans = diff_T.head<2>().norm();
   const auto diff_T_rot = fabs(diff_T(2));
 
-  CLOG(DEBUG, "radar.odometry_icp") << "T_r_m_prev: " << T_r_m_prev;
-  CLOG(DEBUG, "radar.odometry_icp") << "T_r_m_query: " << T_r_m_query;
   CLOG(DEBUG, "radar.odometry_icp") << "Current transformation difference: " << diff_T.transpose();
   CLOG(DEBUG, "radar.odometry_icp") << "Current velocity difference: " << vel_diff.transpose();
 
@@ -735,9 +756,9 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
 
   if (matched_points_ratio > config_->min_matched_ratio && estimate_reasonable && !solver_failed) {
     // undistort the preprocessed pointcloud to eval state (at query timestamp)
-    const auto T_s_m = T_m_s_eval->evaluate().toSE3().matrix().inverse().cast<float>();
-    aligned_mat = T_s_m * aligned_mat;
-    aligned_norms_mat = T_s_m * aligned_norms_mat;
+    const auto T_s_ms = T_s_ms_eval->evaluate().toSE3().matrix().cast<float>();
+    aligned_mat = T_s_ms * aligned_mat;
+    aligned_norms_mat = T_s_ms * aligned_norms_mat;
 
     auto undistorted_point_cloud = std::make_shared<pcl::PointCloud<PointWithInfo>>(aligned_points);
     cart2pol(*undistorted_point_cloud);  // correct polar coordinates.
@@ -745,16 +766,17 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
 
     // store trajectory info
     // odometry at radar scan
-    *qdata.w_m_r_in_r_odo_radar = vec2Dto3D(w_m_r_in_r_eval->value());
-
-    // odometry at extrapolated time
-    *qdata.w_m_r_in_r_odo = vec2Dto3D(w_m_r_in_r_eval_extp->value());
-    // odometry at radar scan
-    *qdata.T_r_m_odo_radar = T_r_m_eval->value().toSE3();
+    const auto T_r_m_odo_radar = T_r_s * T_s_ms_eval->value().toSE3() * T_s_r;
+    const auto w_m_r_in_r_odo_radar = Ad_T_r_s * vec2Dto3D(w_ms_s_in_s_eval->value());
+    *qdata.T_r_m_odo_radar = T_r_m_odo_radar;
+    *qdata.w_m_r_in_r_odo_radar = w_m_r_in_r_odo_radar;
     *qdata.timestamp_odo_radar = scan_stamp;
 
-    // odometry at extr. time
-    *qdata.T_r_m_odo = T_r_m_eval_extp->value().toSE3();
+    // odometry at extrapolated time
+    const auto T_r_m_odo_extp = T_r_s * T_s_ms_eval_extp->value().toSE3() * T_s_r;
+    const auto w_m_r_in_r_odo_extp = Ad_T_r_s * vec2Dto3D(w_ms_s_in_s_eval_extp->value());
+    *qdata.T_r_m_odo = T_r_m_odo_extp;
+    *qdata.w_m_r_in_r_odo = w_m_r_in_r_odo_extp;
     *qdata.timestamp_odo = timestamp_odo_new;
 
     CLOG(DEBUG, "radar.odometry_icp") << "T_m_r is: " << qdata.T_r_m_odo->inverse().vec().transpose();
@@ -764,8 +786,9 @@ void OdometryICPModule::run_(QueryCache &qdata0, OutputCache &,
     *qdata.T_r_v_odo = T_r_m_icp * sliding_map_odo.T_vertex_this().inverse();
     /// \todo double check that we can indeed treat m same as v for velocity
     *qdata.w_v_r_in_r_odo = *qdata.w_m_r_in_r_odo;
-    *qdata.T_r_m_odo_prior = T_r_m_odo_prior_new.toSE3();
-    *qdata.w_m_r_in_r_odo_prior = vec2Dto3D(w_m_r_in_r_odo_prior_new);
+    *qdata.T_r_m_odo_prior = T_r_s * T_s_ms_odo_prior_new.toSE3() * T_s_r;
+    *qdata.w_m_r_in_r_odo_prior = Ad_T_r_s * vec2Dto3D(w_ms_s_in_s_odo_prior_new);
+    // cov_prior_new is in T_s_ms frame, keep it this way for simplicity
     *qdata.cov_prior = cov2Dto3D(cov_prior_new);
     *qdata.timestamp_prior = frame_end_time;
 


### PR DESCRIPTION
The switch to SE(2) radar odometry previously required the radar frame to be aligned with the robot frame. This requirement has now been relaxed to work for any robot frame, which is needed for general robot configurations. Radar ICP odometry now transforms the point map into the radar frame (at the pointmap origin), does SE(2) ICP alignment between the transformed point map and the current radar scan, and then converts all necessary quantities back into the robot frame.

The only downside of this change is that we now do a deep copy of the submap in the odom/loc module. This should be fine since the radar submaps are only ever a few thousand points. This could technically be avoided, but would then require additional repetitive matrix operations per point and per loop, so is done to decrease computation time in exchange for a small increase in memory.

These changes were tested on the industrial route of Boreas-RT with performance actually having a minor odometry bump and a notable localization bump in performance.